### PR TITLE
Bump version up to 1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ MAINTAINER_EMAIL = "alexis.boukouvalas@gmail.com"
 DOWNLOAD_URL = 'https://github.com/ManchesterBioinference/BranchedGP'
 LICENSE = 'MIT'
 
-VERSION = '0.1'
+VERSION = '1.0'
 
 setup(
     name=NAME,


### PR DESCRIPTION
This PR bumps up the version to 1.0. That way, we can release it to PyPI, enabling users to just `pip install BranchedGP==1.0`.