### PR TITLE
Add format checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,3 +35,6 @@ jobs:
 
     - name: Check notebooks are synced with script representations
       run: make check_notebooks_synced
+
+    - name: Check code is correctly formatted
+      run: make check_format

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,7 @@
+[settings]
+profile=hug
+src_paths=BranchedGP,testing,notebooks
+atomic=True
+include_trailing_comma=True
+multi_line_output=3
+ensure_newline_before_comments=True

--- a/BranchedGP/BranchingTree.py
+++ b/BranchedGP/BranchingTree.py
@@ -2,7 +2,7 @@ import numpy as np
 
 
 def checkIndices(indices, XForKernel, Xtrue):
-    '''# Check indices produces XForKernel[] -> same as X (N size) and in addition all rows are taken from X'''
+    """# Check indices produces XForKernel[] -> same as X (N size) and in addition all rows are taken from X"""
     assert Xtrue.shape[1] == XForKernel.shape[1]  # same number of columns
     Xt = Xtrue[:, 0]  # first column
     Xr = np.zeros(Xt.shape)
@@ -10,20 +10,25 @@ def checkIndices(indices, XForKernel, Xtrue):
         Xr[i] = XForKernel[ind[0], 0]  # take the first entry
     assert np.allclose(Xr, Xt)
 
+
 # Utility functions useful to encode/decode function identifiers
+
 
 def GenFunctionName(branchPoint, branchNumber=0):
     assert branchPoint > 0  # Branch id should be non-zero positive
     assert branchNumber == 0 or branchNumber == 1
-    return (branchPoint << 1) + branchNumber  # store in least significant bit function id (0/1)
+    return (
+        branchPoint << 1
+    ) + branchNumber  # store in least significant bit function id (0/1)
 
 
 def GetBranchPtFromFunctionName(functionNumber):
-    if(functionNumber <= 0):
-        NameError('Function id should be non-zero positive. Got ' + str(functionNumber))
-    branchId = (functionNumber >> 1)
-    functionId = (functionNumber & 1)  # function id is 0 or 1
+    if functionNumber <= 0:
+        NameError("Function id should be non-zero positive. Got " + str(functionNumber))
+    branchId = functionNumber >> 1
+    functionId = functionNumber & 1  # function id is 0 or 1
     return (branchId, functionId)
+
 
 #
 # Code the implements binary branching tree
@@ -40,51 +45,63 @@ class BranchingPt:
     # Constructor to create a new binary node
 
     def __init__(self, idB, val):
-        self.idB = idB        # id
-        self.val = val      # value in x space
+        self.idB = idB  # id
+        self.val = val  # value in x space
         self.left = None
         self.right = None
+
 
 # A binary tree
 
 
 class BinaryBranchingTree:
-
     def __init__(self, lbX, ubX, fDebug=False):
         self.root = None
-        self.dictBranch = {}  # dictionary of branching points and their values for quick access
+        self.dictBranch = (
+            {}
+        )  # dictionary of branching points and their values for quick access
         self.dictFunction = {}
         self.lbX = lbX  # lower bound of X
         self.ubX = ubX  # upper bound of X
         self.fDebug = fDebug  # will print out messages
 
     def printTree(self):
-        if(self.root is not None):
+        if self.root is not None:
             self._printTree(self.root, 1)
 
     def _printTree(self, node, ntabs):
-        if(node is not None):
+        if node is not None:
             ntabs += 1
             self._printTree(node.left, ntabs)
-            print('---------' * ntabs + str(node.idB) + '(' + str(node.val) + ')' +
-                  '[' + str(self.dictFunction[node.idB][0]) + ',' + str(self.dictFunction[node.idB][1]) + ']')
+            print(
+                "---------" * ntabs
+                + str(node.idB)
+                + "("
+                + str(node.val)
+                + ")"
+                + "["
+                + str(self.dictFunction[node.idB][0])
+                + ","
+                + str(self.dictFunction[node.idB][1])
+                + "]"
+            )
             self._printTree(node.right, ntabs)
 
     def getRoot(self):
         return self.root
 
     def find(self, idB):
-        if(self.root is not None):
+        if self.root is not None:
             return self._find(idB, self.root)
 
     def _find(self, idB, node):
-        if(idB == node.idB):
+        if idB == node.idB:
             return node
         else:
             n = None
-            if(node.left is not None):
+            if node.left is not None:
                 n = self._find(idB, node.left)
-                if(n is None and node.right is not None):
+                if n is None and node.right is not None:
                     n = self._find(idB, node.right)
             return n
 
@@ -107,8 +124,9 @@ class BinaryBranchingTree:
             return True
 
         # Check if k is found in left or right sub-tree
-        if ((node.left is not None and self._findPath(node.left, path, idB)) or
-                (node.right is not None and self._findPath(node.right, path, idB))):
+        if (node.left is not None and self._findPath(node.left, path, idB)) or (
+            node.right is not None and self._findPath(node.right, path, idB)
+        ):
             return True
 
         # If not present in subtree rooted with root, remove
@@ -124,11 +142,11 @@ class BinaryBranchingTree:
 
         # Check if k is found in left or right sub-tree
         n = None
-        if (node.left is not None):
+        if node.left is not None:
             n = self._findNode(node.left, idB)
-        if(n is None):
+        if n is None:
             # try other child
-            if(node.right is not None):
+            if node.right is not None:
                 n = self._findNode(node.right, idB)
 
         return n
@@ -142,14 +160,14 @@ class BinaryBranchingTree:
 
         # Find paths from root to n1 and root to n2.
         # If either n1 or n2 is not present , return -1
-        if (not self.findPath(path1, idn1)):
-            raise NameError('Could not locate branch point ' + str(idn1))
-        if (not self.findPath(path2, idn2)):
-            raise NameError('Could not locate branch point ' + str(idn2))
+        if not self.findPath(path1, idn1):
+            raise NameError("Could not locate branch point " + str(idn1))
+        if not self.findPath(path2, idn2):
+            raise NameError("Could not locate branch point " + str(idn2))
 
         # Compare the paths to get the first different value
         i = 0
-        while(i < len(path1) and i < len(path2)):
+        while i < len(path1) and i < len(path2):
             if path1[i] != path2[i]:
                 break
             i += 1
@@ -157,37 +175,55 @@ class BinaryBranchingTree:
 
     def add(self, idParent, idB, val):
         # Add branching point
-        if(val < self.lbX or val > self.ubX):
-            raise NameError('Value of node= ' + str(val) +
-                            ' outside bounds [' + str(self.lbX) + ',' + str(self.ubX) + '] ')
+        if val < self.lbX or val > self.ubX:
+            raise NameError(
+                "Value of node= "
+                + str(val)
+                + " outside bounds ["
+                + str(self.lbX)
+                + ","
+                + str(self.ubX)
+                + "] "
+            )
 
-        if(self.root is None):
+        if self.root is None:
             self.root = BranchingPt(idB, val)
             self.dictBranch[idB] = val
-            self.dictFunction[idB] = [GenFunctionName(idB, 0), GenFunctionName(idB, 1)]  # left and right is important
+            self.dictFunction[idB] = [
+                GenFunctionName(idB, 0),
+                GenFunctionName(idB, 1),
+            ]  # left and right is important
         else:
             node = self.find(idParent)
-            if(node is None):
-                raise NameError('Could not find parent id ' + str(idParent))
+            if node is None:
+                raise NameError("Could not find parent id " + str(idParent))
             else:
                 # found the node - it's branching value better be less than ours
-                if(node.val > val):
-                    raise NameError('Trying to add node with greater branch value than parent')
-                if(node.left is None):
+                if node.val > val:
+                    raise NameError(
+                        "Trying to add node with greater branch value than parent"
+                    )
+                if node.left is None:
                     node.left = BranchingPt(idB, val)
                     self.dictBranch[idB] = val
-                    self.dictFunction[idB] = [GenFunctionName(idB, 0), GenFunctionName(idB, 1)]
-                elif(node.right is None):
+                    self.dictFunction[idB] = [
+                        GenFunctionName(idB, 0),
+                        GenFunctionName(idB, 1),
+                    ]
+                elif node.right is None:
                     node.right = BranchingPt(idB, val)
                     self.dictBranch[idB] = val
-                    self.dictFunction[idB] = [GenFunctionName(idB, 0), GenFunctionName(idB, 1)]
+                    self.dictFunction[idB] = [
+                        GenFunctionName(idB, 0),
+                        GenFunctionName(idB, 1),
+                    ]
                 else:
-                    raise NameError('Trying to add node to node with two children')
+                    raise NameError("Trying to add node to node with two children")
 
     def GetBranchValues(self, idBVector=None):
         # Return all branch values with ids in list idBVecotr
         # return type is list
-        if(idBVector is None):
+        if idBVector is None:
             return list(self.dictBranch.values())
         else:
             return [self.dictBranch[idB] for idB in idBVector]
@@ -205,11 +241,11 @@ class BinaryBranchingTree:
         (bid, _) = GetBranchPtFromFunctionName(fid)
         pathBranch = []
         self.findPath(pathBranch, bid)  # find path to that branch
-        if(self.fDebug):
-            print('path branch' + str(pathBranch))
+        if self.fDebug:
+            print("path branch" + str(pathBranch))
         if self.root is None:
             return listOfFunctions
-        if(len(pathBranch) > 0):
+        if len(pathBranch) > 0:
             pathBranch.pop(0)  # is root
             self._findFunctionPath(self.root, pathBranch, listOfFunctions)
 
@@ -217,28 +253,33 @@ class BinaryBranchingTree:
         return listOfFunctions
 
     def _findFunctionPath(self, node, pathBranch, functionPath):
-        if(len(pathBranch) == 0):
+        if len(pathBranch) == 0:
             # print 'End'
             return
 
         idBSearch = pathBranch.pop(0)
-        if(self.fDebug):
-            print('Searching ' + str(idBSearch))
-        if(node.left.idB == idBSearch):
+        if self.fDebug:
+            print("Searching " + str(idBSearch))
+        if node.left.idB == idBSearch:
             functionPath.append(GenFunctionName(node.idB, 0))  # left is 0
             self._findFunctionPath(node.left, pathBranch, functionPath)
-        elif(node.right.idB == idBSearch):
+        elif node.right.idB == idBSearch:
             functionPath.append(GenFunctionName(node.idB, 1))  # right is 1
             self._findFunctionPath(node.right, pathBranch, functionPath)
         else:
-            NameError('Could not find child node id  ' + str(idBSearch) + ' for myself  ' + str(node.idB))
+            NameError(
+                "Could not find child node id  "
+                + str(idBSearch)
+                + " for myself  "
+                + str(node.idB)
+            )
 
     def GetFunctionBranchTensor(self):
         # Create M X M X B tensor that maps function values to branch values
         nb = self.GetNumberOfBranchPts()
         m = 2 * nb + 1  # number of functions
-        if(self.fDebug):
-            print('Number of branch points ' + str(nb) + 'number of functions' + str(m))
+        if self.fDebug:
+            print("Number of branch points " + str(nb) + "number of functions" + str(m))
 
         fm = np.zeros((m, m, nb))  # tensor with branching point ids
         fmb = np.zeros((m, m, nb))  # tensor with branching point values
@@ -251,66 +292,76 @@ class BinaryBranchingTree:
                 fj = fj + 1
                 branchpath = []
 
-                if(fi == fj):
+                if fi == fj:
                     continue
 
                 bid_i, fBin_i = GetBranchPtFromFunctionName(fi)  # branch parent of fi
                 bid_j, fBin_j = GetBranchPtFromFunctionName(fj)  # branch parent of fj
                 pathi = set(self.GetFunctionPath(fi))
                 pathj = set(self.GetFunctionPath(fj))
-                if(pathi <= pathj or pathj <= pathi):
+                if pathi <= pathj or pathj <= pathi:
                     # function subset - they are on the same path
-                    if(pathi <= pathj):
+                    if pathi <= pathj:
                         bid = bid_j  # fj is further along
                         fBin = fBin_j
                     else:
                         bid = bid_i
                         fBin = fBin_i
 
-                    if(self.fDebug):
-                        print('Path to branch point ' + str(bid))
+                    if self.fDebug:
+                        print("Path to branch point " + str(bid))
                     assert self.findPath(branchpath, bid) == True
                     # include all subsequent branch points since they are not visible anyway and will make
                     # matrix well-conditioned
                     node = self._findNode(self.root, bid)  # find the node
                     branchpathFollowing = []
-                    if(fBin == 0 and node.left is not None):  # 0 is left
+                    if fBin == 0 and node.left is not None:  # 0 is left
                         self._GetAllNestedBranchPts(node.left, bid, branchpathFollowing)
-                    elif(fBin == 1 and node.right is not None):  # 1 is right
-                        self._GetAllNestedBranchPts(node.right, bid, branchpathFollowing)
+                    elif fBin == 1 and node.right is not None:  # 1 is right
+                        self._GetAllNestedBranchPts(
+                            node.right, bid, branchpathFollowing
+                        )
                     else:
                         assert fBin == 0 or fBin == 1
 
-                    if(self.fDebug):
-                        print('Following node ids ' + str(branchpathFollowing))
+                    if self.fDebug:
+                        print("Following node ids " + str(branchpathFollowing))
                     branchpath += branchpathFollowing
                 else:
                     # not subsets - they are on different baths, use LCA
                     branchpath = self.findLCAPath(bid_i, bid_j)
-                    if(self.fDebug):
-                        print('LCA path of (' + str(fi) + ',' + str(fj) + ') is ' + str(branchpath))
+                    if self.fDebug:
+                        print(
+                            "LCA path of ("
+                            + str(fi)
+                            + ","
+                            + str(fj)
+                            + ") is "
+                            + str(branchpath)
+                        )
                     assert len(branchpath) > 0
 
                 branchvalues = self._GetBranchValuesAsArray(branchpath)
-                if(self.fDebug):
+                if self.fDebug:
                     print(
-                        'Functions ' +
-                        str(fi) +
-                        ',' +
-                        str(fj) +
-                        ' crosspoints ' +
-                        str(branchpath) +
-                        ', values ' +
-                        str(branchvalues))
-                #fm[fi-1,fj-1,:-(nb - len(branchpath))]=branchpath
-                #fmb[fi-1,fj-1,:-(nb - len(branchpath))]=branchvalues
-                fm[fi - 1, fj - 1, :len(branchpath)] = branchpath
-                fmb[fi - 1, fj - 1, :len(branchpath)] = branchvalues
+                        "Functions "
+                        + str(fi)
+                        + ","
+                        + str(fj)
+                        + " crosspoints "
+                        + str(branchpath)
+                        + ", values "
+                        + str(branchvalues)
+                    )
+                # fm[fi-1,fj-1,:-(nb - len(branchpath))]=branchpath
+                # fmb[fi-1,fj-1,:-(nb - len(branchpath))]=branchvalues
+                fm[fi - 1, fj - 1, : len(branchpath)] = branchpath
+                fmb[fi - 1, fj - 1, : len(branchpath)] = branchvalues
 
         # Check tensor
         # branch ids should form a contiguous set of integers starting at 1
-        if(self.fDebug):
-            print('Tensor fm' + str(fm))
+        if self.fDebug:
+            print("Tensor fm" + str(fm))
         fmFlat = np.ravel(fm)
         fmFlat = fmFlat[~np.isnan(fmFlat)]
         expectedBranchPoints = 1 + np.array(list(range(nb)))
@@ -323,35 +374,43 @@ class BinaryBranchingTree:
         # Get all nested branch pts
         # assumes call on correct nested partition (see node)
         # call _findNode first
-        if(node.idB != bid):  # dont add myself
+        if node.idB != bid:  # dont add myself
             listBranch.append(node.idB)
-        if(node.left is not None):
+        if node.left is not None:
             self._GetAllNestedBranchPts(node.left, bid, listBranch)
-        if(node.right is not None):
+        if node.right is not None:
             self._GetAllNestedBranchPts(node.right, bid, listBranch)
 
     def GetFunctionIndexList(self, Xin, fReturnXtrue=False):
-        ''' Function to return index list  and input array X repeated as many time as each possible function '''
+        """ Function to return index list  and input array X repeated as many time as each possible function """
         # limited to one dimensional X for now!
         assert Xin.shape[0] == np.size(Xin)
         df = self.GetFunctionDomains()
         indicesBranch = []
-        if(np.any(Xin <= df[0, 0])):
-            raise NameError('Value passed in at or less than lower bound ' + str(df[0, 0]))
-        if(np.any(Xin > df[-1, 1])):
-            raise NameError('Value passed in greater than upper bound ' + str(df[-1, 1]))
+        if np.any(Xin <= df[0, 0]):
+            raise NameError(
+                "Value passed in at or less than lower bound " + str(df[0, 0])
+            )
+        if np.any(Xin > df[-1, 1]):
+            raise NameError(
+                "Value passed in greater than upper bound " + str(df[-1, 1])
+            )
 
         Xtrue = np.zeros((Xin.shape[0], 2), dtype=float)
         Xnew = []
         inew = 0
         for ix, x in enumerate(Xin):
-            assignTo = (x > df[:, 0]) & (x <= df[:, 1])        # does where equality is matter check tree search?
+            assignTo = (x > df[:, 0]) & (
+                x <= df[:, 1]
+            )  # does where equality is matter check tree search?
             Xtrue[ix, 0] = Xin[ix]
             functionList = list(np.flatnonzero(assignTo))
             Xtrue[ix, 1] = np.random.choice(functionList) + 1  # one based counting
             idx = []
             for f in functionList:
-                Xnew.append([x, f + 1])  # could have 1 or 0 based function list - does kernel care?
+                Xnew.append(
+                    [x, f + 1]
+                )  # could have 1 or 0 based function list - does kernel care?
                 idx.append(inew)
                 inew = inew + 1
             indicesBranch.append(idx)
@@ -360,7 +419,7 @@ class BinaryBranchingTree:
 
         checkIndices(indicesBranch, Xnewa[:, 0][:, None], Xin[:, None])
 
-        if(fReturnXtrue):
+        if fReturnXtrue:
             return (Xnewa, indicesBranch, Xtrue)
         else:
             return (Xnewa, indicesBranch)
@@ -371,7 +430,7 @@ class BinaryBranchingTree:
         domainF = np.zeros((m, 2))
         domainF[:] = np.NAN
 
-        if(self.root is None):
+        if self.root is None:
             return domainF
 
         # function 1 is always [lb,b1]
@@ -386,13 +445,13 @@ class BinaryBranchingTree:
             assert node.idB == bid
             # function branch point - lower bound is branch point value
             lb = node.val
-            if(fBinaryId == 0):  # 0 is left child
-                if(node.left is None):
+            if fBinaryId == 0:  # 0 is left child
+                if node.left is None:
                     ub = self.ubX
                 else:
                     ub = node.left.val
-            elif(fBinaryId == 1):  # 1 is right child
-                if(node.right is None):
+            elif fBinaryId == 1:  # 1 is right child
+                if node.right is None:
                     ub = self.ubX
                 else:
                     ub = node.right.val

--- a/BranchedGP/FitBranchingModel.py
+++ b/BranchedGP/FitBranchingModel.py
@@ -1,18 +1,31 @@
-import numpy as np
-from . import VBHelperFunctions
-from . import BranchingTree as bt
-from . import branch_kernParamGPflow as bk
-from . import assigngp_denseSparse
-from . import assigngp_dense
+import sys
+import traceback
+
 import gpflow
+import numpy as np
 import tensorflow_probability as tfp
 from gpflow.utilities import print_summary, set_trainable, to_default_float
-import traceback
-import sys
 
-def FitModel(bConsider, GPt, GPy, globalBranching, priorConfidence=0.80,
-             M=10, likvar=1., kerlen=2., kervar=5., fDebug=False, maxiter=100,
-             fPredict=True, fixHyperparameters=False):
+from . import BranchingTree as bt
+from . import VBHelperFunctions, assigngp_dense, assigngp_denseSparse
+from . import branch_kernParamGPflow as bk
+
+
+def FitModel(
+    bConsider,
+    GPt,
+    GPy,
+    globalBranching,
+    priorConfidence=0.80,
+    M=10,
+    likvar=1.0,
+    kerlen=2.0,
+    kervar=5.0,
+    fDebug=False,
+    maxiter=100,
+    fPredict=True,
+    fixHyperparameters=False,
+):
     """
     Fit BGP model
     :param bConsider: list of candidate branching points
@@ -31,13 +44,19 @@ def FitModel(bConsider, GPt, GPy, globalBranching, priorConfidence=0.80,
     :return: dictionary of log likelihood, GPflow model, Phi matrix, predictive set of points,
     mean and variance, hyperparameter values, posterior on branching time
     """
-    assert isinstance(bConsider, list), 'Candidate B must be list'
+    assert isinstance(bConsider, list), "Candidate B must be list"
     assert GPt.ndim == 1
     assert GPy.ndim == 2
-    assert GPt.size == GPy.size, 'pseudotime and gene expression data must be the same size'
-    assert globalBranching.size == GPy.size, 'state space must be same size as number of cells'
-    assert M >= 0, 'at least 0 or more inducing points should be given'
-    phiInitial, phiPrior = GetInitialConditionsAndPrior(globalBranching, priorConfidence, infPriorPhi=True)
+    assert (
+        GPt.size == GPy.size
+    ), "pseudotime and gene expression data must be the same size"
+    assert (
+        globalBranching.size == GPy.size
+    ), "state space must be same size as number of cells"
+    assert M >= 0, "at least 0 or more inducing points should be given"
+    phiInitial, phiPrior = GetInitialConditionsAndPrior(
+        globalBranching, priorConfidence, infPriorPhi=True
+    )
 
     XExpanded, indices, _ = VBHelperFunctions.GetFunctionIndexListGeneral(GPt)
     ptb = np.min([np.min(GPt[globalBranching == 2]), np.min(GPt[globalBranching == 3])])
@@ -45,34 +64,60 @@ def FitModel(bConsider, GPt, GPy, globalBranching, priorConfidence=0.80,
     tree.add(None, 1, np.ones((1, 1)) * ptb)  # B can be anything here
     (fm, _) = tree.GetFunctionBranchTensor()
 
-    kb = bk.BranchKernelParam(gpflow.kernels.Matern32(1), fm, b=np.zeros((1, 1))) + gpflow.kernels.White(1)
-    kb.kernels[1].variance.assign(1e-6)  # controls the discontinuity magnitude, the gap at the branching point
+    kb = bk.BranchKernelParam(
+        gpflow.kernels.Matern32(1), fm, b=np.zeros((1, 1))
+    ) + gpflow.kernels.White(1)
+    kb.kernels[1].variance.assign(
+        1e-6
+    )  # controls the discontinuity magnitude, the gap at the branching point
     set_trainable(kb.kernels[1].variance, False)  # jitter for numerics
-    if(M == 0):
-        m = assigngp_dense.AssignGP(GPt, XExpanded, GPy, kb, indices,
-                                                np.ones((1, 1)) * ptb, phiInitial=phiInitial,
-                                                phiPrior=phiPrior)
+    if M == 0:
+        m = assigngp_dense.AssignGP(
+            GPt,
+            XExpanded,
+            GPy,
+            kb,
+            indices,
+            np.ones((1, 1)) * ptb,
+            phiInitial=phiInitial,
+            phiPrior=phiPrior,
+        )
     else:
         ZExpanded = np.ones((M, 2))
         ZExpanded[:, 0] = np.linspace(0, 1, M, endpoint=False)
         ZExpanded[:, 1] = np.array([i for j in range(M) for i in range(1, 4)])[:M]
-        m = assigngp_denseSparse.AssignGPSparse(GPt, XExpanded, GPy, kb, indices,
-                                                np.ones((1, 1)) * ptb, ZExpanded, phiInitial=phiInitial, phiPrior=phiPrior)
+        m = assigngp_denseSparse.AssignGPSparse(
+            GPt,
+            XExpanded,
+            GPy,
+            kb,
+            indices,
+            np.ones((1, 1)) * ptb,
+            ZExpanded,
+            phiInitial=phiInitial,
+            phiPrior=phiPrior,
+        )
     # Initialise hyperparameters
     m.likelihood.variance.assign(likvar)
     m.kernel.kernels[0].kern.lengthscales.assign(kerlen)
     m.kernel.kernels[0].kern.variance.assign(kervar)
-    if(fixHyperparameters):
-        print('Fixing hyperparameters')
+    if fixHyperparameters:
+        print("Fixing hyperparameters")
         set_trainable(m.kernel.kernels[0].kern.lengthscales, False)
         set_trainable(m.likelihood.variance, False)
         set_trainable(m.kernel.kernels[0].kern.variance, False)
     else:
         if fDebug:
-            print('Adding prior logistic on length scale to avoid numerical problems')
-        m.kernel.kernels[0].kern.lengthscales.prior = tfp.distributions.Normal(to_default_float(2.), to_default_float(1.))
-        m.kernel.kernels[0].kern.variance.prior = tfp.distributions.Normal(to_default_float(3.), to_default_float(1.))
-        m.likelihood.variance.prior = tfp.distributions.Normal(to_default_float(.1), to_default_float(.1))
+            print("Adding prior logistic on length scale to avoid numerical problems")
+        m.kernel.kernels[0].kern.lengthscales.prior = tfp.distributions.Normal(
+            to_default_float(2.0), to_default_float(1.0)
+        )
+        m.kernel.kernels[0].kern.variance.prior = tfp.distributions.Normal(
+            to_default_float(3.0), to_default_float(1.0)
+        )
+        m.likelihood.variance.prior = tfp.distributions.Normal(
+            to_default_float(0.1), to_default_float(0.1)
+        )
 
     # optimization
     ll = np.zeros(len(bConsider))
@@ -83,28 +128,41 @@ def FitModel(bConsider, GPt, GPy, globalBranching, priorConfidence=0.80,
         m.UpdateBranchingPoint(np.ones((1, 1)) * b, phiInitial)
         try:
             opt = gpflow.optimizers.Scipy()
-            opt.minimize(m.training_loss, variables=m.trainable_variables,
-                         options=dict(disp=True, maxiter=maxiter))
+            opt.minimize(
+                m.training_loss,
+                variables=m.trainable_variables,
+                options=dict(disp=True, maxiter=maxiter),
+            )
             # remember winning hyperparameter
-            hyps.append({'likvar':  m.likelihood.variance.numpy(), 'kerlen':  m.kernel.kernels[0].kern.lengthscales.numpy(),
-                    'kervar': m.kernel.kernels[0].kern.variance.numpy()})
+            hyps.append(
+                {
+                    "likvar": m.likelihood.variance.numpy(),
+                    "kerlen": m.kernel.kernels[0].kern.lengthscales.numpy(),
+                    "kervar": m.kernel.kernels[0].kern.variance.numpy(),
+                }
+            )
             ll[ib] = m.log_posterior_density()
         except:
-            print('Failure', "Unexpected error:", sys.exc_info()[0])
-            print('-' * 60)
+            print("Failure", "Unexpected error:", sys.exc_info()[0])
+            print("-" * 60)
             traceback.print_exc(file=sys.stdout)
-            print('Exception caused by model')
+            print("Exception caused by model")
             print(m)
-            print('-' * 60)
+            print("-" * 60)
             ll[0] = np.nan
             # return model so can inspect model
-            return {'loglik': ll, 'model': m, 'Phi': np.nan,
-                    'prediction': {'xtest': np.nan, 'mu': np.nan, 'var': np.nan},
-                    'hyperparameters': np.nan, 'posteriorB': np.nan}
+            return {
+                "loglik": ll,
+                "model": m,
+                "Phi": np.nan,
+                "prediction": {"xtest": np.nan, "mu": np.nan, "var": np.nan},
+                "hyperparameters": np.nan,
+                "posteriorB": np.nan,
+            }
         # prediction
         Phi = m.GetPhi()
         Phi_l.append(Phi)
-        if(fPredict):
+        if fPredict:
             ttestl, mul, varl = VBHelperFunctions.predictBranchingModel(m)
             ttestl_l.append(ttestl), mul_l.append(mul), varl_l.append(varl)
         else:
@@ -112,35 +170,46 @@ def FitModel(bConsider, GPt, GPy, globalBranching, priorConfidence=0.80,
     iw = np.argmax(ll)
     postB = GetPosteriorB(ll, bConsider)
     if fDebug:
-        print('BGP Maximum at b=%.2f' % bConsider[iw], 'CI= [%.2f, %.2f]' %(postB['B_CI'][0], postB['B_CI'][1]))
-    assert np.allclose(bConsider[iw], postB['Bmode']), '%s-%s' % str(postB['B_CI'], bConsider[iw])
-    return {'loglik': ll, 'Phi': Phi_l[iw], # 'model': m,
-            'prediction': {'xtest': ttestl_l[iw], 'mu': mul_l[iw], 'var': varl_l[iw]},
-            'hyperparameters': hyps[iw], 'posteriorB': postB}
-
+        print(
+            "BGP Maximum at b=%.2f" % bConsider[iw],
+            "CI= [%.2f, %.2f]" % (postB["B_CI"][0], postB["B_CI"][1]),
+        )
+    assert np.allclose(bConsider[iw], postB["Bmode"]), "%s-%s" % str(
+        postB["B_CI"], bConsider[iw]
+    )
+    return {
+        "loglik": ll,
+        "Phi": Phi_l[iw],  # 'model': m,
+        "prediction": {"xtest": ttestl_l[iw], "mu": mul_l[iw], "var": varl_l[iw]},
+        "hyperparameters": hyps[iw],
+        "posteriorB": postB,
+    }
 
 
 def GetPosteriorB(objUnsorted, BgridSearch, ciLimits=[0.01, 0.99]):
-    '''
+    """
     Return posterior on B for each experiment, confidence interval index, map index
-    '''
+    """
     # for each trueB calculate posterior over grid
     # ... in a numerically stable way
-    assert objUnsorted.size == len(BgridSearch), 'size do not match %g-%g' % (objUnsorted.size, len(BgridSearch))
+    assert objUnsorted.size == len(BgridSearch), "size do not match %g-%g" % (
+        objUnsorted.size,
+        len(BgridSearch),
+    )
     gr = np.array(BgridSearch)
     isort = np.argsort(gr)
     gr = gr[isort]
     o = objUnsorted[isort].copy()  # sorted objective funtion
     imode = np.argmax(o)
     pn = np.exp(o - np.max(o))
-    p = pn/pn.sum()
-    assert np.any(~np.isnan(p)), 'Nans in p! %s' % str(p)
-    assert np.any(~np.isinf(p)), 'Infinities in p! %s' % str(p)
+    p = pn / pn.sum()
+    assert np.any(~np.isnan(p)), "Nans in p! %s" % str(p)
+    assert np.any(~np.isinf(p)), "Infinities in p! %s" % str(p)
     pb_cdf = np.cumsum(p)
     confInt = np.zeros(len(ciLimits), dtype=int)
     for pb_i, pb_c in enumerate(ciLimits):
         pb_idx = np.flatnonzero(pb_cdf <= pb_c)
-        if(pb_idx.size == 0):
+        if pb_idx.size == 0:
             confInt[pb_i] = 0
         else:
             confInt[pb_i] = np.max(pb_idx)
@@ -151,33 +220,46 @@ def GetPosteriorB(objUnsorted, BgridSearch, ciLimits=[0.01, 0.99]):
     B_CI = gr[confInt]
     Bmode = gr[imode]
     # return confidence interval as well as mode, and indexes for each
-    return {'B_CI': B_CI, 'Bmode': Bmode, 'idx_confInt': confInt, 'idx_mode': imode, 'BgridSearch_sort': gr, 'isort': isort}
-
-
+    return {
+        "B_CI": B_CI,
+        "Bmode": Bmode,
+        "idx_confInt": confInt,
+        "idx_mode": imode,
+        "BgridSearch_sort": gr,
+        "isort": isort,
+    }
 
 
 def GetInitialConditionsAndPrior(globalBranching, v, infPriorPhi):
     # Setting initial phi
     np.random.seed(42)  # UNDONE remove TODO
-    assert isinstance(v, float), 'v should be scalar is %s' % str(type(v))
+    assert isinstance(v, float), "v should be scalar is %s" % str(type(v))
     N = globalBranching.size
-    phiInitial = np.ones((N, 2))*0.5  # don't know anything
+    phiInitial = np.ones((N, 2)) * 0.5  # don't know anything
     phiInitial[:, 0] = np.random.rand(N)
-    phiInitial[:, 1] = 1-phiInitial[:, 0]
+    phiInitial[:, 1] = 1 - phiInitial[:, 0]
     phiPrior = np.ones_like(phiInitial) * 0.5  # don't know anything
     for i in range(N):
-        iBranch = globalBranching[i]-2  # is 1,2,3-> -1, 0, 1
-        if(iBranch == -1):
+        iBranch = globalBranching[i] - 2  # is 1,2,3-> -1, 0, 1
+        if iBranch == -1:
             # trunk - set all equal
             phiPrior[i, :] = 0.5
         else:
-            if(infPriorPhi):
-                phiPrior[i, :] = 1-v
+            if infPriorPhi:
+                phiPrior[i, :] = 1 - v
                 phiPrior[i, int(iBranch)] = v
-            phiInitial[i, int(iBranch)] = 0.5 + (np.random.random() / 2.)  # number between [0.5, 1]
-            phiInitial[i, int(iBranch) != np.array([0, 1])] = 1 - phiInitial[i, int(iBranch)]
-    assert np.allclose(phiPrior.sum(1), 1), 'Phi Prior should be close to 1 but got %s' % str(phiPrior)
-    assert np.allclose(phiInitial.sum(1), 1), 'Phi Initial should be close to 1 but got %s' % str(phiInitial)
-    assert np.all(~np.isnan(phiInitial)), 'No nans please!'
-    assert np.all(~np.isnan(phiPrior)), 'No nans please!'
+            phiInitial[i, int(iBranch)] = 0.5 + (
+                np.random.random() / 2.0
+            )  # number between [0.5, 1]
+            phiInitial[i, int(iBranch) != np.array([0, 1])] = (
+                1 - phiInitial[i, int(iBranch)]
+            )
+    assert np.allclose(
+        phiPrior.sum(1), 1
+    ), "Phi Prior should be close to 1 but got %s" % str(phiPrior)
+    assert np.allclose(
+        phiInitial.sum(1), 1
+    ), "Phi Initial should be close to 1 but got %s" % str(phiInitial)
+    assert np.all(~np.isnan(phiInitial)), "No nans please!"
+    assert np.all(~np.isnan(phiPrior)), "No nans please!"
     return phiInitial, phiPrior

--- a/BranchedGP/VBHelperFunctions.py
+++ b/BranchedGP/VBHelperFunctions.py
@@ -1,6 +1,7 @@
 import numpy as np
 from matplotlib import pyplot as plt
 
+
 def CalculateBranchingEvidence(d, Bsearch=None):
     """
     :param d: output dictionary from FitModel
@@ -11,24 +12,39 @@ def CalculateBranchingEvidence(d, Bsearch=None):
     if Bsearch is None:
         Bsearch = list(np.linspace(0.05, 0.95, 5)) + [1.1]
     # Calculate probability of branching at each point
-    o = d['loglik'][:-1]
+    o = d["loglik"][:-1]
     pn = np.exp(o - np.max(o))
-    p = pn/pn.sum()  # normalize
+    p = pn / pn.sum()  # normalize
 
     # Calculate log likelihood ratio by averaging out
-    o = d['loglik']
+    o = d["loglik"]
     Nb = o.size - 1
     if Nb != len(Bsearch) - 1:
-        raise NameError('Passed in wrong length of Bsearch is %g- should be %g' % (len(Bsearch), Nb))
+        raise NameError(
+            "Passed in wrong length of Bsearch is %g- should be %g" % (len(Bsearch), Nb)
+        )
     obj = o[:-1]
     illmax = np.argmax(obj)
     llmax = obj[illmax]
-    lratiostable = llmax + np.log(1 + np.exp(obj[np.arange(obj.size) != illmax]-llmax).sum()) - o[-1] - np.log(Nb)
+    lratiostable = (
+        llmax
+        + np.log(1 + np.exp(obj[np.arange(obj.size) != illmax] - llmax).sum())
+        - o[-1]
+        - np.log(Nb)
+    )
 
-    return {'posteriorBranching': p, 'logBayesFactor': lratiostable}
+    return {"posteriorBranching": p, "logBayesFactor": lratiostable}
 
 
-def PlotBGPFit(GPy, GPt, Bsearch, d, figsize=(5, 5), height_ratios= [5, 1], colorarray=['darkolivegreen', 'peru', 'mediumvioletred']):
+def PlotBGPFit(
+    GPy,
+    GPt,
+    Bsearch,
+    d,
+    figsize=(5, 5),
+    height_ratios=[5, 1],
+    colorarray=["darkolivegreen", "peru", "mediumvioletred"],
+):
     """
     Plot BGP model
     :param GPt: pseudotime
@@ -41,9 +57,11 @@ def PlotBGPFit(GPy, GPt, Bsearch, d, figsize=(5, 5), height_ratios= [5, 1], colo
     :return: dictionary of log likelihood, GPflow model, Phi matrix, predictive set of points,
     mean and variance, hyperparameter values, posterior on branching time
     """
-    fig, axa = plt.subplots(2, 1, figsize=figsize, sharex=True,  gridspec_kw = {'height_ratios': height_ratios})
+    fig, axa = plt.subplots(
+        2, 1, figsize=figsize, sharex=True, gridspec_kw={"height_ratios": height_ratios}
+    )
     ax = axa[0]
-    y, pt, mul, ttestl = GPy, GPt, d['prediction']['mu'], d['prediction']['xtest']
+    y, pt, mul, ttestl = GPy, GPt, d["prediction"]["mu"], d["prediction"]["xtest"]
     lw = 4
     for f in range(3):
         mu = mul[f]
@@ -51,18 +69,36 @@ def PlotBGPFit(GPy, GPt, Bsearch, d, figsize=(5, 5), height_ratios= [5, 1], colo
         col = colorarray[f]  # mean.get_color()
         ax.plot(ttest, mu, linewidth=lw, color=col, alpha=0.7)
         gp_num = 1  # can be 0,1,2 - Plot against this
-        PhiColor = ax.scatter(pt, y, c=d['Phi'][:, gp_num], vmin=0., vmax=1, s=40, alpha=0.7)
+        PhiColor = ax.scatter(
+            pt, y, c=d["Phi"][:, gp_num], vmin=0.0, vmax=1, s=40, alpha=0.7
+        )
     _ = fig.colorbar(PhiColor, ax=ax, orientation="horizontal")
     ax = axa[1]
-    p = CalculateBranchingEvidence(d, Bsearch)['posteriorBranching']
+    p = CalculateBranchingEvidence(d, Bsearch)["posteriorBranching"]
     ax.stem(Bsearch[:-1], p)
     return fig, axa
 
 
-def plotBranchModel(B, pt, Y, ttestl, mul, varl, Phi, figsizeIn=(5, 5), lw=3., fs=10, labels=None,
-                    fPlotPhi=True, fPlotVar=False, ax=None, fColorBar=True, colorarray = ['darkolivegreen', 'peru', 'mediumvioletred']):
-    ''' Plotting code that does not require access to the model but takes as input predictions. '''
-    if(ax is None):
+def plotBranchModel(
+    B,
+    pt,
+    Y,
+    ttestl,
+    mul,
+    varl,
+    Phi,
+    figsizeIn=(5, 5),
+    lw=3.0,
+    fs=10,
+    labels=None,
+    fPlotPhi=True,
+    fPlotVar=False,
+    ax=None,
+    fColorBar=True,
+    colorarray=["darkolivegreen", "peru", "mediumvioletred"],
+):
+    """ Plotting code that does not require access to the model but takes as input predictions. """
+    if ax is None:
         fig = plt.figure(figsize=figsizeIn)
         ax = fig.gca()
     else:
@@ -73,25 +109,37 @@ def plotBranchModel(B, pt, Y, ttestl, mul, varl, Phi, figsizeIn=(5, 5), lw=3., f
         var = varl[f].numpy()
         ttest = ttestl[f]
         col = colorarray[f]  # mean.get_color()
-        mean, = ax.plot(ttest, mu[:, d], linewidth=lw, color=col)
-        if(fPlotVar):
-            ax.plot(ttest.flatten(), mu[:, d] + 2 * np.sqrt(var.flatten()), '--', color=col, linewidth=lw)
-            ax.plot(ttest, mu[:, d] - 2 * np.sqrt(var.flatten()), '--', color=col, linewidth=lw)
+        (mean,) = ax.plot(ttest, mu[:, d], linewidth=lw, color=col)
+        if fPlotVar:
+            ax.plot(
+                ttest.flatten(),
+                mu[:, d] + 2 * np.sqrt(var.flatten()),
+                "--",
+                color=col,
+                linewidth=lw,
+            )
+            ax.plot(
+                ttest,
+                mu[:, d] - 2 * np.sqrt(var.flatten()),
+                "--",
+                color=col,
+                linewidth=lw,
+            )
     v = ax.axis()
-    ax.plot([B, B], v[-2:], '-m', linewidth=lw)
+    ax.plot([B, B], v[-2:], "-m", linewidth=lw)
     # Plot Phi or labels
-    if(fPlotPhi):
+    if fPlotPhi:
         gp_num = 1  # can be 0,1,2 - Plot against this
-        PhiColor = ax.scatter(pt, Y[:, d], c=Phi[:, gp_num], vmin=0., vmax=1, s=40)
-        if(fColorBar):
-            fig.colorbar(PhiColor, label='GP {} assignment probability'.format(gp_num))
+        PhiColor = ax.scatter(pt, Y[:, d], c=Phi[:, gp_num], vmin=0.0, vmax=1, s=40)
+        if fColorBar:
+            fig.colorbar(PhiColor, label="GP {} assignment probability".format(gp_num))
         else:
             return fig, PhiColor
     return fig
 
 
 def predictBranchingModel(m, full_cov=False):
-    ''' return prediction of branching model '''
+    """ return prediction of branching model """
     pt = m.t
     B = m.kernel.kernels[0].Bv.flatten()
     l = np.min(pt)
@@ -100,16 +148,20 @@ def predictBranchingModel(m, full_cov=False):
     varl = list()
     ttestl = list()
     for f in range(1, 4):
-        if(f == 1):
-            ttest = np.linspace(l, B, 100)#[:, None]  # root
+        if f == 1:
+            ttest = np.linspace(l, B, 100)  # [:, None]  # root
         else:
-            ttest = np.linspace(B, u, 100)#[:, None]
+            ttest = np.linspace(B, u, 100)  # [:, None]
         Xtest = np.hstack((ttest, ttest * 0 + f))
         mu, var = m.predict_f(Xtest, full_cov=full_cov)
         idx = np.isnan(mu)
         # print('munan', mu[idx], var[idx], ttest[idx])
-        assert np.all(np.isfinite(mu)), 'All elements should be finite but are ' + str(mu)
-        assert np.all(np.isfinite(var)), 'All elements should be finite but are ' + str(var)
+        assert np.all(np.isfinite(mu)), "All elements should be finite but are " + str(
+            mu
+        )
+        assert np.all(np.isfinite(var)), "All elements should be finite but are " + str(
+            var
+        )
         mul.append(mu)
         varl.append(var)
         ttestl.append(ttest)
@@ -117,7 +169,7 @@ def predictBranchingModel(m, full_cov=False):
 
 
 def GetFunctionIndexListGeneral(Xin):
-    ''' Function to return index list  and input array X repeated as many time as each possible function '''
+    """ Function to return index list  and input array X repeated as many time as each possible function """
     # limited to one dimensional X for now!
     assert Xin.shape[0] == np.size(Xin)
     indicesBranch = []
@@ -125,7 +177,9 @@ def GetFunctionIndexListGeneral(Xin):
     XSample = np.zeros((Xin.shape[0], 2), dtype=float)
     Xnew = []
     inew = 0
-    functionList = list(range(1, 4))  # can be assigned to any of root or subbranches, one based counting
+    functionList = list(
+        range(1, 4)
+    )  # can be assigned to any of root or subbranches, one based counting
 
     for ix, x in enumerate(Xin):
         XSample[ix, 0] = Xin[ix]
@@ -142,9 +196,13 @@ def GetFunctionIndexListGeneral(Xin):
 
 
 def SetXExpandedBranchingPoint(XExpanded, B):
-    ''' Return XExpanded by removing unavailable branches '''
+    """ Return XExpanded by removing unavailable branches """
     # before branching pt, only function 1
-    X1 = XExpanded[np.logical_and(XExpanded[:, 0] <= B, XExpanded[:, 1] == 1).flatten(), :]
+    X1 = XExpanded[
+        np.logical_and(XExpanded[:, 0] <= B, XExpanded[:, 1] == 1).flatten(), :
+    ]
     # after branching pt, only functions 2 and 2
-    X23 = XExpanded[np.logical_and(XExpanded[:, 0] > B, XExpanded[:, 1] != 1).flatten(), :]
+    X23 = XExpanded[
+        np.logical_and(XExpanded[:, 0] > B, XExpanded[:, 1] != 1).flatten(), :
+    ]
     return np.vstack([X1, X23])

--- a/BranchedGP/__init__.py
+++ b/BranchedGP/__init__.py
@@ -1,3 +1,10 @@
 # flake8: noqa
-from . import assigngp_dense, assigngp_denseSparse, branch_kernParamGPflow,\
-    BranchingTree, pZ_construction_singleBP, VBHelperFunctions, FitBranchingModel
+from . import (
+    BranchingTree,
+    FitBranchingModel,
+    VBHelperFunctions,
+    assigngp_dense,
+    assigngp_denseSparse,
+    branch_kernParamGPflow,
+    pZ_construction_singleBP,
+)

--- a/BranchedGP/assigngp_dense.py
+++ b/BranchedGP/assigngp_dense.py
@@ -2,12 +2,14 @@
 import gpflow
 import numpy as np
 import tensorflow as tf
-from . import pZ_construction_singleBP
-
 from gpflow.mean_functions import Zero
 
+from . import pZ_construction_singleBP
 
-class AssignGP(gpflow.models.model.GPModel, gpflow.models.InternalDataTrainingLossMixin):
+
+class AssignGP(
+    gpflow.models.model.GPModel, gpflow.models.InternalDataTrainingLossMixin
+):
     """
     Gaussian Process regression, but where the index to which the data are
     assigned is unknown.
@@ -28,97 +30,130 @@ class AssignGP(gpflow.models.model.GPModel, gpflow.models.InternalDataTrainingLo
 
     """
 
-    def __init__(self, t, XExpanded, Y, kern, indices, b, phiPrior=None, phiInitial=None, fDebug=False, KConst=None):
-        super().__init__(kernel=kern, likelihood=gpflow.likelihoods.Gaussian(), mean_function=Zero(), num_latent_gps=Y.shape[-1])
-        assert len(indices) == t.size, 'indices must be size N'
-        assert len(t.shape) == 1, 'pseudotime should be 1D'
+    def __init__(
+        self,
+        t,
+        XExpanded,
+        Y,
+        kern,
+        indices,
+        b,
+        phiPrior=None,
+        phiInitial=None,
+        fDebug=False,
+        KConst=None,
+    ):
+        super().__init__(
+            kernel=kern,
+            likelihood=gpflow.likelihoods.Gaussian(),
+            mean_function=Zero(),
+            num_latent_gps=Y.shape[-1],
+        )
+        assert len(indices) == t.size, "indices must be size N"
+        assert len(t.shape) == 1, "pseudotime should be 1D"
         self.Y = Y
         self.X = XExpanded
         self.N = t.shape[0]
-        self.t = t.astype(gpflow.default_float()) # could be DataHolder? advantages
+        self.t = t.astype(gpflow.default_float())  # could be DataHolder? advantages
         self.indices = indices
-        self.logPhi = gpflow.Parameter(np.random.randn(t.shape[0], t.shape[0] * 3))  # 1 branch point => 3 functions
-        if(phiInitial is None):
-            phiInitial = np.ones((self.N, 2))*0.5  # dont know anything
+        self.logPhi = gpflow.Parameter(
+            np.random.randn(t.shape[0], t.shape[0] * 3)
+        )  # 1 branch point => 3 functions
+        if phiInitial is None:
+            phiInitial = np.ones((self.N, 2)) * 0.5  # dont know anything
             phiInitial[:, 0] = np.random.rand(self.N)
-            phiInitial[:, 1] = 1-phiInitial[:, 0]
+            phiInitial[:, 1] = 1 - phiInitial[:, 0]
         self.fDebug = fDebug
         # Used as p(Z) prior in KL term. This should add to 1 but will do so after UpdatePhPrior
-        if(phiPrior is None):
+        if phiPrior is None:
             phiPrior = np.ones((self.N, 2)) * 0.5
         # Fix prior term - this is without trunk
         self.pZ = np.ones((t.shape[0], t.shape[0] * 3))
         self.UpdateBranchingPoint(b, phiInitial, prior=phiPrior)
         self.KConst = KConst
-        if(not fDebug):
-            assert KConst is None, 'KConst only for debugging'
+        if not fDebug:
+            assert KConst is None, "KConst only for debugging"
 
     def UpdateBranchingPoint(self, b, phiInitial, prior=None):
-        ''' Function to update branching point and optionally reset initial conditions for variational phi'''
+        """ Function to update branching point and optionally reset initial conditions for variational phi"""
         assert isinstance(b, np.ndarray)
-        assert b.size == 1, 'Must have scalar branching point'
+        assert b.size == 1, "Must have scalar branching point"
         self.b = b.astype(gpflow.default_float())  # remember branching value
-        assert self.kernel.kernels[0].name == 'branch_kernel_param'
+        assert self.kernel.kernels[0].name == "branch_kernel_param"
         self.kernel.kernels[0].Bv = b
-        assert self.logPhi.trainable is True, 'Phi should not be constant when changing branching location'
+        assert (
+            self.logPhi.trainable is True
+        ), "Phi should not be constant when changing branching location"
         if prior is not None:
             self.eZ0 = pZ_construction_singleBP.expand_pZ0Zeros(prior)
         self.pZ = pZ_construction_singleBP.expand_pZ0PureNumpyZeros(self.eZ0, b, self.t)
         self.InitialiseVariationalPhi(phiInitial)
 
     def InitialiseVariationalPhi(self, phiInitialIn):
-        ''' Set initial state for Phi using branching location to constrain.
+        """Set initial state for Phi using branching location to constrain.
         This code has to be consistent with pZ_construction.singleBP.make_matrix to where
         the equality is placed i.e. if x<=b trunk and if x>b branch or vice versa. We use the
-         former convention.'''
-        assert np.allclose(phiInitialIn.sum(1), 1), 'probs must sum to 1 %s' % str(phiInitialIn)
-        assert self.b == self.kernel.kernels[0].Bv, 'Need to call UpdateBranchingPoint'
+         former convention."""
+        assert np.allclose(phiInitialIn.sum(1), 1), "probs must sum to 1 %s" % str(
+            phiInitialIn
+        )
+        assert self.b == self.kernel.kernels[0].Bv, "Need to call UpdateBranchingPoint"
         N = self.Y.shape[0]
         assert phiInitialIn.shape[0] == N
         assert phiInitialIn.shape[1] == 2  # run OMGP with K=2 trajectories
         phiInitialEx = np.zeros((N, 3 * N))
         # large neg number makes exact zeros, make smaller for added jitter
-        phiInitial_invSoftmax = -9. * np.ones((N, 3 * N))
+        phiInitial_invSoftmax = -9.0 * np.ones((N, 3 * N))
         eps = 1e-9
         iterC = 0
         for i, p in enumerate(self.t):
-            if(p > self.b):  # before branching - it's the root
-                phiInitialEx[i, iterC:iterC + 3] = np.hstack([eps, phiInitialIn[i, :] - eps])
+            if p > self.b:  # before branching - it's the root
+                phiInitialEx[i, iterC : iterC + 3] = np.hstack(
+                    [eps, phiInitialIn[i, :] - eps]
+                )
             else:
-                phiInitialEx[i, iterC:iterC + 3] = np.array([1 - 2 * eps, 0 + eps, 0 + eps])
-            phiInitial_invSoftmax[i, iterC:iterC + 3] = np.log(phiInitialEx[i, iterC:iterC + 3])
+                phiInitialEx[i, iterC : iterC + 3] = np.array(
+                    [1 - 2 * eps, 0 + eps, 0 + eps]
+                )
+            phiInitial_invSoftmax[i, iterC : iterC + 3] = np.log(
+                phiInitialEx[i, iterC : iterC + 3]
+            )
             iterC += 3
-        assert not np.any(np.isnan(phiInitialEx)), 'no nans please ' + str(np.nonzero(np.isnan(phiInitialEx)))
-        assert not np.any(phiInitialEx < -eps), 'no negatives please ' + str(np.nonzero(np.isnan(phiInitialEx)))
+        assert not np.any(np.isnan(phiInitialEx)), "no nans please " + str(
+            np.nonzero(np.isnan(phiInitialEx))
+        )
+        assert not np.any(phiInitialEx < -eps), "no negatives please " + str(
+            np.nonzero(np.isnan(phiInitialEx))
+        )
         self.logPhi.assign(phiInitial_invSoftmax)
 
     def GetPhi(self):
-        ''' Get Phi matrix, collapsed for each possible entry '''
-        assert self.b == self.kernel.kernels[0].Bv, 'Need to call UpdateBranchingPoint'
+        """ Get Phi matrix, collapsed for each possible entry """
+        assert self.b == self.kernel.kernels[0].Bv, "Need to call UpdateBranchingPoint"
         phiExpanded = self.GetPhiExpanded().numpy()
         l = [phiExpanded[i, self.indices[i]] for i in range(len(self.indices))]
         phi = np.asarray(l)
         tolError = 1e-6
-        assert np.all(phi.sum(1) <= 1+tolError)
-        assert np.all(phi >= 0-tolError)
-        assert np.all(phi <= 1+tolError)
+        assert np.all(phi.sum(1) <= 1 + tolError)
+        assert np.all(phi >= 0 - tolError)
+        assert np.all(phi <= 1 + tolError)
         return phi
 
     def GetPhiExpanded(self):
-        ''' Shortcut function to get Phi matrix out.'''
+        """ Shortcut function to get Phi matrix out."""
         return tf.nn.softmax(self.logPhi)
 
     def objectiveFun(self):
-        ''' Objective function to minimize - log likelihood -log prior.
-        Unlike _objective, no gradient calculation is performed.'''
-        return -self.log_posterior_density()-self.log_prior_density()
+        """Objective function to minimize - log likelihood -log prior.
+        Unlike _objective, no gradient calculation is performed."""
+        return -self.log_posterior_density() - self.log_prior_density()
 
     def maximum_log_likelihood_objective(self):
-        print('assignegp_dense compiling model (build_likelihood)')
+        print("assignegp_dense compiling model (build_likelihood)")
         N = tf.cast(tf.shape(self.Y)[0], dtype=gpflow.default_float())
         M = tf.shape(self.X)[0]
         D = tf.cast(tf.shape(self.Y)[1], dtype=gpflow.default_float())
-        if(self.KConst is not None):
+        if self.KConst is not None:
             K = tf.cast(self.KConst, gpflow.default_float())
         else:
             K = self.kernel.K(self.X)
@@ -126,33 +161,42 @@ class AssignGP(gpflow.models.model.GPModel, gpflow.models.InternalDataTrainingLo
         # try squashing Phi to avoid numerical errors
         Phi = (1 - 2e-6) * Phi + 1e-6
         sigma2 = self.likelihood.variance
-        tau = 1. / self.likelihood.variance
-        L = tf.linalg.cholesky(K) + tf.eye(M, dtype=gpflow.default_float()) * gpflow.default_jitter()
+        tau = 1.0 / self.likelihood.variance
+        L = (
+            tf.linalg.cholesky(K)
+            + tf.eye(M, dtype=gpflow.default_float()) * gpflow.default_jitter()
+        )
         W = tf.transpose(L) * tf.sqrt(tf.reduce_sum(Phi, 0)) / tf.sqrt(sigma2)
-        P = tf.linalg.matmul(W, tf.transpose(W)) + tf.eye(M, dtype=gpflow.default_float())
+        P = tf.linalg.matmul(W, tf.transpose(W)) + tf.eye(
+            M, dtype=gpflow.default_float()
+        )
         R = tf.linalg.cholesky(P)
         PhiY = tf.linalg.matmul(tf.transpose(Phi), self.Y)
         LPhiY = tf.linalg.matmul(tf.transpose(L), PhiY)
-        if(self.fDebug):
-            tf.print(Phi, [tf.shape(P), P], name='P', summarize=10)
-            tf.print(Phi, [tf.shape(LPhiY), LPhiY], name='LPhiY', summarize=10)
-            tf.print(Phi, [tf.shape(K), K], name='K', summarize=10)
-            tf.print(Phi, [tau], name='tau', summarize=10)
+        if self.fDebug:
+            tf.print(Phi, [tf.shape(P), P], name="P", summarize=10)
+            tf.print(Phi, [tf.shape(LPhiY), LPhiY], name="LPhiY", summarize=10)
+            tf.print(Phi, [tf.shape(K), K], name="K", summarize=10)
+            tf.print(Phi, [tau], name="tau", summarize=10)
         c = tf.linalg.triangular_solve(R, LPhiY, lower=True) / sigma2
         # compute KL
         KL = self.build_KL(Phi)
-        a1 = -0.5 * N * D * tf.math.log(2. * np.pi / tau)
-        a2 = - 0.5 * D * tf.math.reduce_sum(tf.math.log(tf.math.square(tf.linalg.diag_part(R))))
-        a3 = - 0.5 * tf.math.reduce_sum(tf.math.square(self.Y)) / sigma2
-        a4 = + 0.5 * tf.math.reduce_sum(tf.math.square(c))
-        a5 = - KL
-        if(self.fDebug):
-            tf.print(a1, [a1], name='a1=')
-            tf.print(a2, [a2], name='a2=')
-            tf.print(a3, [a3], name='a3=')
-            tf.print(a4, [a4], name='a4=')
-            tf.print(a5, [a5, Phi], name='a5 and Phi=', summarize=10)
-        return a1+a2+a3+a4+a5
+        a1 = -0.5 * N * D * tf.math.log(2.0 * np.pi / tau)
+        a2 = (
+            -0.5
+            * D
+            * tf.math.reduce_sum(tf.math.log(tf.math.square(tf.linalg.diag_part(R))))
+        )
+        a3 = -0.5 * tf.math.reduce_sum(tf.math.square(self.Y)) / sigma2
+        a4 = +0.5 * tf.math.reduce_sum(tf.math.square(c))
+        a5 = -KL
+        if self.fDebug:
+            tf.print(a1, [a1], name="a1=")
+            tf.print(a2, [a2], name="a2=")
+            tf.print(a3, [a3], name="a3=")
+            tf.print(a4, [a4], name="a4=")
+            tf.print(a5, [a5, Phi], name="a5 and Phi=", summarize=10)
+        return a1 + a2 + a3 + a4 + a5
 
     def predict_f(self, Xnew, full_cov=False):
         M = tf.shape(self.X)[0]
@@ -161,9 +205,14 @@ class AssignGP(gpflow.models.model.GPModel, gpflow.models.InternalDataTrainingLo
         # try squashing Phi to avoid numerical errors
         Phi = (1 - 2e-6) * Phi + 1e-6
         sigma2 = self.likelihood.variance
-        L = tf.linalg.cholesky(K) + tf.eye(M, dtype=gpflow.default_float()) * gpflow.default_jitter()
+        L = (
+            tf.linalg.cholesky(K)
+            + tf.eye(M, dtype=gpflow.default_float()) * gpflow.default_jitter()
+        )
         W = tf.transpose(L) * tf.sqrt(tf.math.reduce_sum(Phi, 0)) / tf.sqrt(sigma2)
-        P = tf.linalg.matmul(W, tf.transpose(W)) + tf.eye(M, dtype=gpflow.default_float())
+        P = tf.linalg.matmul(W, tf.transpose(W)) + tf.eye(
+            M, dtype=gpflow.default_float()
+        )
         R = tf.linalg.cholesky(P)
         PhiY = tf.linalg.matmul(tf.transpose(Phi), self.Y)
         LPhiY = tf.linalg.matmul(tf.transpose(L), PhiY)
@@ -173,16 +222,24 @@ class AssignGP(gpflow.models.model.GPModel, gpflow.models.InternalDataTrainingLo
         tmp2 = tf.linalg.triangular_solve(R, tmp1, lower=True)
         mean = tf.linalg.matmul(tf.transpose(tmp2), c)
         if full_cov:
-            var = self.kernel.K(Xnew) + tf.linalg.matmul(tf.transpose(tmp2), tmp2)\
+            var = (
+                self.kernel.K(Xnew)
+                + tf.linalg.matmul(tf.transpose(tmp2), tmp2)
                 - tf.linalg.matmul(tf.transpose(tmp1), tmp1)
+            )
             shape = tf.stack([1, 1, tf.shape(self.Y)[1]])
             var = tf.tile(tf.expand_dims(var, 2), shape)
         else:
-            var = self.kernel.K_diag(Xnew) + tf.math.reduce_sum(tf.math.square(tmp2), 0)\
+            var = (
+                self.kernel.K_diag(Xnew)
+                + tf.math.reduce_sum(tf.math.square(tmp2), 0)
                 - tf.math.reduce_sum(tf.math.square(tmp1), 0)
+            )
             shape = tf.stack([1, tf.shape(self.Y)[1]])
             var = tf.tile(tf.expand_dims(var, 1), shape)
         return mean, var
 
     def build_KL(self, Phi):
-        return tf.math.reduce_sum(Phi * tf.math.log(Phi)) - tf.math.reduce_sum(Phi * tf.math.log(self.pZ))
+        return tf.math.reduce_sum(Phi * tf.math.log(Phi)) - tf.math.reduce_sum(
+            Phi * tf.math.log(self.pZ)
+        )

--- a/BranchedGP/assigngp_denseSparse.py
+++ b/BranchedGP/assigngp_denseSparse.py
@@ -2,7 +2,9 @@
 import gpflow
 import numpy as np
 import tensorflow as tf
+
 from . import assigngp_dense
+
 
 class AssignGPSparse(assigngp_dense.AssignGP):
     """
@@ -25,27 +27,52 @@ class AssignGPSparse(assigngp_dense.AssignGP):
 
     """
 
-    def __init__(self, t, XExpanded, Y, kern, indices, b, ZExpanded, fDebug=False, phiInitial=None, phiPrior=None):
-        assigngp_dense.AssignGP.__init__(self, t, XExpanded, Y, kern, indices, b, fDebug=fDebug,
-                                         phiInitial=phiInitial, phiPrior=phiPrior)
+    def __init__(
+        self,
+        t,
+        XExpanded,
+        Y,
+        kern,
+        indices,
+        b,
+        ZExpanded,
+        fDebug=False,
+        phiInitial=None,
+        phiPrior=None,
+    ):
+        assigngp_dense.AssignGP.__init__(
+            self,
+            t,
+            XExpanded,
+            Y,
+            kern,
+            indices,
+            b,
+            fDebug=fDebug,
+            phiInitial=phiInitial,
+            phiPrior=phiPrior,
+        )
         # Do not treat inducing points as parameters because they should always be fixed.
         self.ZExpanded = ZExpanded  # inducing points for sparse GP. Same as XExpanded
         assert ZExpanded.shape[1] == XExpanded.shape[1]
 
     def maximum_log_likelihood_objective(self):
         if self.fDebug:
-            print('assignegp_denseSparse compiling model (build_likelihood)')
+            print("assignegp_denseSparse compiling model (build_likelihood)")
         N = tf.cast(tf.shape(self.Y)[0], dtype=gpflow.default_float())
         M = tf.shape(self.ZExpanded)[0]
         D = tf.cast(tf.shape(self.Y)[1], dtype=gpflow.default_float())
 
         Phi = tf.nn.softmax(self.logPhi)
         # try squashing Phi to avoid numerical errors
-        Phi = (1-2e-6) * Phi + 1e-6
+        Phi = (1 - 2e-6) * Phi + 1e-6
 
         sigma2 = self.likelihood.variance
         sigma = tf.sqrt(self.likelihood.variance)
-        Kuu = self.kernel.K(self.ZExpanded) + tf.eye(M, dtype=gpflow.default_float()) * gpflow.default_jitter()
+        Kuu = (
+            self.kernel.K(self.ZExpanded)
+            + tf.eye(M, dtype=gpflow.default_float()) * gpflow.default_jitter()
+        )
         Kuf = self.kernel.K(self.ZExpanded, self.X)
 
         Kdiag = self.kernel.K_diag(self.X)
@@ -53,20 +80,29 @@ class AssignGPSparse(assigngp_dense.AssignGP):
         A = tf.math.reduce_sum(Phi, 0)
         LiKuf = tf.linalg.triangular_solve(L, Kuf)
         W = LiKuf * tf.sqrt(A) / sigma
-        P = tf.linalg.matmul(W, tf.transpose(W)) + tf.eye(M, dtype=gpflow.default_float())
-        traceTerm = -0.5 * tf.math.reduce_sum(Kdiag * A) / sigma2 + 0.5 * tf.math.reduce_sum(tf.math.square(W))
+        P = tf.linalg.matmul(W, tf.transpose(W)) + tf.eye(
+            M, dtype=gpflow.default_float()
+        )
+        traceTerm = -0.5 * tf.math.reduce_sum(
+            Kdiag * A
+        ) / sigma2 + 0.5 * tf.math.reduce_sum(tf.math.square(W))
         R = tf.linalg.cholesky(P)
         tmp = tf.linalg.matmul(LiKuf, tf.linalg.matmul(tf.transpose(Phi), self.Y))
         c = tf.linalg.triangular_solve(R, tmp, lower=True) / sigma2
-        if(self.fDebug):
+        if self.fDebug:
             # trace term should be 0 for Z=X (full data)
-            tf.print([traceTerm], name='traceTerm', summarize=10)
+            tf.print([traceTerm], name="traceTerm", summarize=10)
 
-        self.bound = traceTerm - 0.5*N*D*tf.math.log(2 * np.pi * sigma2)\
-            - 0.5*D*tf.math.reduce_sum(tf.math.log(tf.math.square(tf.linalg.diag_part(R))))\
-            - 0.5*tf.math.reduce_sum(tf.math.square(self.Y)) / sigma2\
-            + 0.5*tf.math.reduce_sum(tf.math.square(c))\
+        self.bound = (
+            traceTerm
+            - 0.5 * N * D * tf.math.log(2 * np.pi * sigma2)
+            - 0.5
+            * D
+            * tf.math.reduce_sum(tf.math.log(tf.math.square(tf.linalg.diag_part(R))))
+            - 0.5 * tf.math.reduce_sum(tf.math.square(self.Y)) / sigma2
+            + 0.5 * tf.math.reduce_sum(tf.math.square(c))
             - self.build_KL(Phi)
+        )
 
         return self.bound
 
@@ -75,18 +111,23 @@ class AssignGPSparse(assigngp_dense.AssignGP):
 
         Phi = tf.nn.softmax(self.logPhi)
         # try squashing Phi to avoid numerical errors
-        Phi = (1-2e-6) * Phi + 1e-6
+        Phi = (1 - 2e-6) * Phi + 1e-6
 
         sigma2 = self.likelihood.variance
         sigma = tf.sqrt(sigma2)
-        Kuu = self.kernel.K(self.ZExpanded) + tf.eye(M, dtype=gpflow.default_float()) * gpflow.default_jitter()
+        Kuu = (
+            self.kernel.K(self.ZExpanded)
+            + tf.eye(M, dtype=gpflow.default_float()) * gpflow.default_jitter()
+        )
         Kuf = self.kernel.K(self.ZExpanded, self.X)
         L = tf.linalg.cholesky(Kuu)
 
         p = tf.math.reduce_sum(Phi, 0)
         LiKuf = tf.linalg.triangular_solve(L, Kuf)
         W = LiKuf * tf.sqrt(p) / sigma
-        P = tf.linalg.matmul(W, tf.transpose(W)) + tf.eye(M, dtype=gpflow.default_float())
+        P = tf.linalg.matmul(W, tf.transpose(W)) + tf.eye(
+            M, dtype=gpflow.default_float()
+        )
         R = tf.linalg.cholesky(P)
         tmp = tf.linalg.matmul(LiKuf, tf.linalg.matmul(tf.transpose(Phi), self.Y))
         c = tf.linalg.triangular_solve(R, tmp, lower=True) / sigma2
@@ -96,13 +137,19 @@ class AssignGPSparse(assigngp_dense.AssignGP):
         tmp2 = tf.linalg.triangular_solve(R, tmp1, lower=True)
         mean = tf.linalg.matmul(tf.transpose(tmp2), c)
         if full_cov:
-            var = self.kernel.K(Xnew) + tf.linalg.matmul(tf.transpose(tmp2), tmp2)\
+            var = (
+                self.kernel.K(Xnew)
+                + tf.linalg.matmul(tf.transpose(tmp2), tmp2)
                 - tf.linalg.matmul(tf.transpose(tmp1), tmp1)
+            )
             shape = tf.stack([1, 1, tf.shape(self.Y)[1]])
             var = tf.tile(tf.expand_dims(var, 2), shape)
         else:
-            var = self.kernel.K_diag(Xnew) + tf.math.reduce_sum(tf.math.square(tmp2), 0)\
+            var = (
+                self.kernel.K_diag(Xnew)
+                + tf.math.reduce_sum(tf.math.square(tmp2), 0)
                 - tf.math.reduce_sum(tf.math.square(tmp1), 0)
+            )
             shape = tf.stack([1, tf.shape(self.Y)[1]])
             var = tf.tile(tf.expand_dims(var, 1), shape)
         return mean, var

--- a/BranchedGP/branch_kernParamGPflow.py
+++ b/BranchedGP/branch_kernParamGPflow.py
@@ -1,50 +1,52 @@
-''' Module to replace branch_kern with parameterised version'''
-from . import VBHelperFunctions
+""" Module to replace branch_kern with parameterised version"""
 import gpflow
-import tensorflow as tf
 import numpy as np
+import tensorflow as tf
+from gpflow.kernels import Kernel
 from matplotlib import pyplot as plt
 
-from gpflow.kernels import Kernel
+from . import VBHelperFunctions
 
-def PlotSample(X, samples, B=None, lw=5., fs=20, figsizeIn=(5, 5)):
+
+def PlotSample(X, samples, B=None, lw=5.0, fs=20, figsizeIn=(5, 5)):
     D = samples.shape[1]  # number of outputs
     assert X.shape[0] == samples.shape[0]
     M = 3  # number of functions
-    assert B is None or B.size == 1, 'Limited to one branch point'
+    assert B is None or B.size == 1, "Limited to one branch point"
     _, ax = plt.subplots(D, 1, figsize=figsizeIn, sharex=True, sharey=True)
     for d in range(D):
         for i in range(1, M + 1):
             t = X[X[:, 1] == i, 0]
             y = samples[X[:, 1] == i, d]
-            if(t.size == 0):
+            if t.size == 0:
                 continue
-            if(D != 1):
+            if D != 1:
                 p = ax.flatten()[d]
             else:
                 p = ax
-            p.plot(t, y, '-+', label=i, markersize=2 * lw)
+            p.plot(t, y, "-+", label=i, markersize=2 * lw)
             p.text(t[int(t.size / 2)], y[int(t.size / 2)], str(i), fontsize=fs)
         # Add vertical lines for branch points
-        if(B is not None):
+        if B is not None:
             v = p.axis()
-            p.set_title('Branching kernel at B=%g' % B)
+            p.set_title("Branching kernel at B=%g" % B)
             for i in range(B.size):
-                p.plot([B[i], B[i]], v[-2:], '--r')
+                p.plot([B[i], B[i]], v[-2:], "--r")
 
 
 def SampleKernel(kern, X, D=1, tol=1e-6, retChol=False):
-    ''' Sample GP, D is number of independent output dimensions '''
+    """ Sample GP, D is number of independent output dimensions """
     K = kern.K(X, X)  # NxM
     L = np.linalg.cholesky(K + np.eye(K.shape[0]) * tol)
     samples = L.dot(np.random.randn(L.shape[0], D))
-    if(retChol):
+    if retChol:
         return samples, L, K
     else:
         return samples
 
+
 def GetFunctionIndexSample(Xin):
-    ''' Function to return index list  and input array X repeated as many time as each possible function '''
+    """ Function to return index list  and input array X repeated as many time as each possible function """
     # limited to one dimensional X for now!
     N = Xin.shape[0]
     assert Xin.shape[0] == np.size(Xin)
@@ -57,10 +59,9 @@ def GetFunctionIndexSample(Xin):
 
 
 class BranchKernelParam(Kernel):
-
     def __init__(self, base_kern, branchPtTensor, b, fDebug=False):
-        ''' branchPtTensor is tensor of branch points of size F X F X B where F the number of
-        functions and B the number of branching points '''
+        """branchPtTensor is tensor of branch points of size F X F X B where F the number of
+        functions and B the number of branching points"""
         super().__init__()
         self.kern = base_kern
         self.fm = branchPtTensor
@@ -71,36 +72,40 @@ class BranchKernelParam(Kernel):
         self.Bv = b
 
     def SampleKernel(self, XExpanded, b=None, tol=1e-6):
-        if(b is not None):
-            self.Bv = np.ones((1, 1))*b
+        if b is not None:
+            self.Bv = np.ones((1, 1)) * b
         XTree = VBHelperFunctions.SetXExpandedBranchingPoint(XExpanded, self.Bv)
         return SampleKernel(self, XTree, tol=tol), XTree
 
     def SampleKernelFromTree(self, XTree, b, tol=1e-6):
-        ''' Sample kernel with assignments already done. '''
-        self.Bv = np.ones((1, 1))*b
-        assert np.all(XTree[XTree[:, 0] <= b, 1] == 1), 'Before branch point trunk is function 1.'
+        """ Sample kernel with assignments already done. """
+        self.Bv = np.ones((1, 1)) * b
+        assert np.all(
+            XTree[XTree[:, 0] <= b, 1] == 1
+        ), "Before branch point trunk is function 1."
         return SampleKernel(self, XTree, tol=tol)
 
     def K(self, X, Y=None):
         if Y is None:
             Y = X  # hack to avoid duplicating code below
 
-        if(self.fDebug):
-            print('Compiling kernel')
+        if self.fDebug:
+            print("Compiling kernel")
         t1s = tf.expand_dims(X[:, 0], 1)  # N X 1
         t2s = tf.expand_dims(Y[:, 0], 1)
         i1s_r = tf.expand_dims(X[:, 1], 1)
         i2s_r = tf.expand_dims(Y[:, 1], 1)
-        if(self.fDebug):
+        if self.fDebug:
             snl = 10  # how many entries to print
             i1s = i1s_r
             i2s = i2s_r
 
-            tf.print([tf.shape(i1s_r), i1s_r],
-                           name='i1sdebug', summarize=snl)  # will print message
-            tf.print([tf.shape(i2s_r), i2s_r],
-                           name='i2sdebug', summarize=snl)  # will print message
+            tf.print(
+                [tf.shape(i1s_r), i1s_r], name="i1sdebug", summarize=snl
+            )  # will print message
+            tf.print(
+                [tf.shape(i2s_r), i2s_r], name="i2sdebug", summarize=snl
+            )  # will print message
         else:
             i1s = i1s_r
             i2s = i2s_r
@@ -111,62 +116,97 @@ class BranchKernelParam(Kernel):
 
         Ktts = self.kern.K(t1s, t2s)  # N*M X N*M
         with tf.name_scope("kttscope"):  # scope
-            same_functions = tf.equal(i1s_matrix, tf.transpose(i2s_matrix), name='FiEQFj')
-            K_s = tf.where(same_functions, Ktts, Ktts, name='selectFiEQFj')  # just setup matrix with block diagonal
+            same_functions = tf.equal(
+                i1s_matrix, tf.transpose(i2s_matrix), name="FiEQFj"
+            )
+            K_s = tf.where(
+                same_functions, Ktts, Ktts, name="selectFiEQFj"
+            )  # just setup matrix with block diagonal
 
         m = self.fm.shape[0]
         for fi in range(m):
             for fj in range(m):
-                if (fi != fj):
+                if fi != fj:
                     with tf.name_scope("f" + str(fi) + "f" + str(fj)):  # scope
                         # much easier to remove nans before tensorflow
                         bnan = self.fm[fi, fj, ~np.isnan(self.fm[fi, fj, :])]
-                        fi_s = tf.constant(fi + 1, tf.int32, name='function' + str(fi))
-                        fj_s = tf.constant(fj + 1, tf.int32, name='function' + str(fj))
+                        fi_s = tf.constant(fi + 1, tf.int32, name="function" + str(fi))
+                        fj_s = tf.constant(fj + 1, tf.int32, name="function" + str(fj))
 
-                        i1s_matrixInt = tf.cast(i1s_matrix, tf.int32, name='casti1s')
-                        i2s_matrixTInt = tf.cast(i2s_matrixT, tf.int32, name='casti2s')
+                        i1s_matrixInt = tf.cast(i1s_matrix, tf.int32, name="casti1s")
+                        i2s_matrixTInt = tf.cast(i2s_matrixT, tf.int32, name="casti2s")
 
-                        fiFilter = fi_s * tf.ones_like(i1s_matrixInt, tf.int32, name='fiFilter')
-                        fjFilter = fj_s * tf.ones_like(i2s_matrixTInt, tf.int32, name='fjFilter')  # must be transpose
+                        fiFilter = fi_s * tf.ones_like(
+                            i1s_matrixInt, tf.int32, name="fiFilter"
+                        )
+                        fjFilter = fj_s * tf.ones_like(
+                            i2s_matrixTInt, tf.int32, name="fjFilter"
+                        )  # must be transpose
 
-                        f1F = tf.equal(i1s_matrixInt, fiFilter, name='indexF' + str(fi))
-                        f2F = tf.equal(i2s_matrixTInt, fjFilter, name='indexF' + str(fj))
+                        f1F = tf.equal(i1s_matrixInt, fiFilter, name="indexF" + str(fi))
+                        f2F = tf.equal(
+                            i2s_matrixTInt, fjFilter, name="indexF" + str(fj)
+                        )
 
-                        t12F = tf.logical_and(f1F, f2F, name='F' + str(fi) + 'andF' + str(fj))
+                        t12F = tf.logical_and(
+                            f1F, f2F, name="F" + str(fi) + "andF" + str(fj)
+                        )
 
                         # Get the actual values of the Bs = B[index of relevant branching points]
                         bint = bnan.astype(int)  # convert to int - set of indexes
-                        if(self.fDebug):
+                        if self.fDebug:
                             Br = self.Bv
-                            tf.print([tf.shape(self.Bv), self.Bv], name='Bv', summarize=3)  # will print message
+                            tf.print(
+                                [tf.shape(self.Bv), self.Bv], name="Bv", summarize=3
+                            )  # will print message
                         else:
                             Br = self.Bv
-                        Bs = ((tf.concat([tf.slice(Br, [i - 1, 0], [1, 1]) for i in bint], 0)))
+                        Bs = tf.concat(
+                            [tf.slice(Br, [i - 1, 0], [1, 1]) for i in bint], 0
+                        )
 
-                        kbb = self.kern.K(Bs) + tf.linalg.diag(tf.ones(tf.shape(Bs)[:1], dtype=gpflow.default_float())) * gpflow.default_jitter()
-                        if(self.fDebug):
-                            tf.print([tf.shape(kbb), kbb], name='kbb', summarize=10)
-                            tf.print([self.kern.lengthscales.numpy()], name='lenscales', summarize=10)
-                            tf.print([self.kern.variance.numpy()], name='lenscales', summarize=10)
-                            tf.print([Bs], name='Bs', summarize=10)
+                        kbb = (
+                            self.kern.K(Bs)
+                            + tf.linalg.diag(
+                                tf.ones(tf.shape(Bs)[:1], dtype=gpflow.default_float())
+                            )
+                            * gpflow.default_jitter()
+                        )
+                        if self.fDebug:
+                            tf.print([tf.shape(kbb), kbb], name="kbb", summarize=10)
+                            tf.print(
+                                [self.kern.lengthscales.numpy()],
+                                name="lenscales",
+                                summarize=10,
+                            )
+                            tf.print(
+                                [self.kern.variance.numpy()],
+                                name="lenscales",
+                                summarize=10,
+                            )
+                            tf.print([Bs], name="Bs", summarize=10)
 
-                        Kbbs_inv = tf.linalg.inv(kbb, name='invKbb')  # B X B
+                        Kbbs_inv = tf.linalg.inv(kbb, name="invKbb")  # B X B
                         Kb1s = self.kern.K(t1s, Bs)  # N*m X B
                         Kb2s = self.kern.K(t2s, Bs)  # N*m X B
 
                         a = tf.linalg.matmul(Kb1s, Kbbs_inv)
-                        K_crosss = tf.linalg.matmul(a, tf.transpose(Kb2s), name='Kt1_Bi_invBB_KBt2')
+                        K_crosss = tf.linalg.matmul(
+                            a, tf.transpose(Kb2s), name="Kt1_Bi_invBB_KBt2"
+                        )
 
-                        K_s = tf.where(t12F, K_crosss, K_s, name='selectIndex')
+                        K_s = tf.where(t12F, K_crosss, K_s, name="selectIndex")
         return K_s
 
     def K_diag(self, X):
-        return tf.linalg.diag_part(self.kern.K(X))  # diagonal is just single point no branch point relevant
+        return tf.linalg.diag_part(
+            self.kern.K(X)
+        )  # diagonal is just single point no branch point relevant
 
 
 class IndKern(Kernel):
-    ''' an independent output kernel '''
+    """ an independent output kernel """
+
     def __init__(self, base_kern):
         super().__init__()
         self.kern = base_kern
@@ -190,5 +230,3 @@ class IndKern(Kernel):
 
     def K_diag(self, X):
         return tf.linalg.diag_part(self.kern.K(X))
-
-

--- a/BranchedGP/pZ_construction_singleBP.py
+++ b/BranchedGP/pZ_construction_singleBP.py
@@ -1,17 +1,19 @@
+import gpflow
 import numpy as np
 import tensorflow as tf
-import gpflow
+
 
 def expand_pZ0Zeros(pZ0, epsilon=1e-6):
-    assert pZ0.shape[1] == 2, 'Should have exactly two cols got %g ' % pZ0.shape[1]
+    assert pZ0.shape[1] == 2, "Should have exactly two cols got %g " % pZ0.shape[1]
     num_columns = 3 * pZ0.shape[0]
     r = np.zeros((pZ0.shape[0], num_columns)) + epsilon
     count = 0
     for iz0, z0 in enumerate(pZ0):
-        assert z0.sum() == 1, 'should sum to 1 is %s=%.3f' % (str(z0), z0.sum())
-        r[iz0, count+1:count+3] = z0
+        assert z0.sum() == 1, "should sum to 1 is %s=%.3f" % (str(z0), z0.sum())
+        r[iz0, count + 1 : count + 3] = z0
         count += 3
     return r
+
 
 def expand_pZ0PureNumpyZeros(eZ0, BP, X, epsilon=1e-6):
     N = X.size
@@ -19,28 +21,29 @@ def expand_pZ0PureNumpyZeros(eZ0, BP, X, epsilon=1e-6):
     count = 0
     i = np.flatnonzero(X <= BP)
     # mark trunk as [1, 0, 0]
-    r[i, i*3] = 1
+    r[i, i * 3] = 1
     r[i, i * 3 + 1] = epsilon
     r[i, i * 3 + 2] = epsilon
     return r
 
+
 def expand_pZ0(pZ0):
-    assert pZ0.shape[1] == 2, 'Should have exactly two cols got %g ' % pZ0.shape[1]
+    assert pZ0.shape[1] == 2, "Should have exactly two cols got %g " % pZ0.shape[1]
     num_columns = 3 * pZ0.shape[0]
     r = np.ones((pZ0.shape[0], num_columns))
     count = 0
     for iz0, z0 in enumerate(pZ0):
-        assert z0.sum() == 1, 'should sum to 1 is %s=%.3f' % (str(z0), z0.sum())
-        r[iz0, count+1:count+3] = z0
+        assert z0.sum() == 1, "should sum to 1 is %s=%.3f" % (str(z0), z0.sum())
+        r[iz0, count + 1 : count + 3] = z0
         count += 3
     return r
 
 
 def make_matrix(X, BP, eZ0, epsilon=1e-6):
-    ''' Compute pZ which is N by N*3 matrix of prior assignment.
+    """Compute pZ which is N by N*3 matrix of prior assignment.
     This code has to be consistent with assigngp_dense.InitialiseVariationalPhi to where
         the equality is placed i.e. if x<=b trunk and if x>b branch or vice versa. We use the
-         former convention.'''
+         former convention."""
     num_columns = 3 * tf.shape(X)[0]  # for 3 latent fns
     rows = []
     count = tf.zeros((1,), dtype=tf.int32)
@@ -50,16 +53,21 @@ def make_matrix(X, BP, eZ0, epsilon=1e-6):
         n = tf.cast(tf.greater(x, BP), tf.int32) + 1
         # n == 1 when x <= BP
         # n == 2 when x > BP
-        row = [tf.zeros(count + n - 1, dtype=gpflow.default_float()) + epsilon]  # all entries until count are zero
+        row = [
+            tf.zeros(count + n - 1, dtype=gpflow.default_float()) + epsilon
+        ]  # all entries until count are zero
         # add 1's for possible entries
         probs = tf.ones(n, dtype=gpflow.default_float())
         row.append(probs)
-        row.append(tf.zeros(2 - 2 * (n - 1), dtype=gpflow.default_float()) + epsilon)  # append zero
+        row.append(
+            tf.zeros(2 - 2 * (n - 1), dtype=gpflow.default_float()) + epsilon
+        )  # append zero
         count += 3
-        row.append(tf.zeros(num_columns - count, dtype=gpflow.default_float()) + epsilon)
+        row.append(
+            tf.zeros(num_columns - count, dtype=gpflow.default_float()) + epsilon
+        )
         # ensure things are correctly shaped
-        row = tf.concat(row, 0, name='singleconcat')
+        row = tf.concat(row, 0, name="singleconcat")
         row = tf.expand_dims(row, 0)
         rows.append(row)
-    return tf.multiply(tf.concat(rows, 0, name='multiconcat'), eZ0)
-
+    return tf.multiply(tf.concat(rows, 0, name="multiconcat"), eZ0)

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@
 TEST_PATH=testing
 TEST_REQUIREMENTS=test_requirements.txt
 NOTEBOOK_PATH=notebooks
+PACKAGE_PATH=BranchedGP
+ALL_CODE_PATHS=$(TEST_PATH) $(NOTEBOOK_PATH) $(PACKAGE_PATH)
 
 
 ##################################
@@ -53,25 +55,25 @@ test:
 	nosetests $(TEST_PATH)
 
 check_black:
-	black --check .
+	black --check $(ALL_CODE_PATHS)
 
 check_isort:
-	isort --diff .
+	isort --diff $(ALL_CODE_PATHS)
 
 check_format: check_black check_isort
 
 isort:
-	isort --skip-glob=.tox --recursive .
+	isort --recursive $(ALL_CODE_PATHS)
 
 black:
-	black .
+	black $(ALL_CODE_PATHS)
 
 format: isort black
 
 lint:
-	flake8 --max-line-length 120 BranchedGP
+	flake8 --max-line-length 120 $(ALL_CODE_PATHS)
 
 mypy:
-	mypy --ignore-missing-imports BranchedGP
+	mypy --ignore-missing-imports $(ALL_CODE_PATHS)
 
 static_checks: mypy lint

--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,19 @@ check_isort:
 
 check_format: check_black check_isort
 
-isort:
-	isort $(ALL_CODE_PATHS)
+isort_code:
+	isort $(PACKAGE_PATH) $(TEST_PATH)
 
-black:
-	black $(ALL_CODE_PATHS)
+isort_notebooks:
+	jupytext --pipe 'isort - --treat-comment-as-code "# %%" --float-to-top' $(NOTEBOOK_PATH)/*.ipynb
 
-format: isort black
+black_code:
+	black $(PACKAGE_PATH) $(TEST_PATH)
+
+black_notebooks:
+	jupytext --sync --pipe black $(NOTEBOOK_PATH)/*.ipynb
+
+format: isort_code black_code isort_notebooks black_notebooks
 
 lint:
 	flake8 --max-line-length 120 $(ALL_CODE_PATHS)

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ check_isort:
 check_format: check_black check_isort
 
 isort:
-	isort --recursive $(ALL_CODE_PATHS)
+	isort $(ALL_CODE_PATHS)
 
 black:
 	black $(ALL_CODE_PATHS)

--- a/README.md
+++ b/README.md
@@ -105,3 +105,12 @@ Commit both the notebook as well as the paired notebook.
 
 If Jupyter shows you a warning about the notebook being
 out of sync with the master script, run `make sync_notebooks`.
+
+## Formatting code
+
+We automatically check that all contributions are formatted
+according to the recommendations by
+[black](https://black.readthedocs.io/en/stable/) and
+[isort](https://pycqa.github.io/isort/).
+If your changes fail these checks, all you need to do is run
+`make format` and commit the changes.

--- a/notebooks/Hematopoiesis.ipynb
+++ b/notebooks/Hematopoiesis.ipynb
@@ -24,10 +24,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd\n",
+    "import time\n",
+    "\n",
     "import numpy as np\n",
+    "import pandas as pd\n",
     "from matplotlib import pyplot as plt\n",
-    "plt.style.use('ggplot')\n",
+    "\n",
+    "import BranchedGP\n",
+    "\n",
+    "plt.style.use(\"ggplot\")\n",
     "%matplotlib inline"
    ]
   },
@@ -45,8 +50,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Y = pd.read_csv('singlecelldata/hematoData.csv', index_col=[0])\n",
-    "monocle = pd.read_csv('singlecelldata/hematoMonocle.csv', index_col=[0])"
+    "Y = pd.read_csv(\"singlecelldata/hematoData.csv\", index_col=[0])\n",
+    "monocle = pd.read_csv(\"singlecelldata/hematoMonocle.csv\", index_col=[0])"
    ]
   },
   {
@@ -352,6 +357,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
+    "lines_to_next_cell": 1,
     "scrolled": true
    },
    "outputs": [
@@ -370,15 +376,22 @@
    ],
    "source": [
     "# Plot Monocle DDRTree space\n",
-    "genelist = ['FLT3','KLF1','MPO']\n",
+    "genelist = [\"FLT3\", \"KLF1\", \"MPO\"]\n",
     "f, ax = plt.subplots(1, len(genelist), figsize=(10, 5), sharex=True, sharey=True)\n",
     "for ig, g in enumerate(genelist):\n",
-    "        y = Y[g].values\n",
-    "        yt = np.log(1+y/y.max())\n",
-    "        yt = yt/yt.max()\n",
-    "        h = ax[ig].scatter(monocle['DDRTreeDim1'], monocle['DDRTreeDim2'],\n",
-    "                       c=yt, s=50, alpha=1.0, vmin=0, vmax=1)\n",
-    "        ax[ig].set_title(g)"
+    "    y = Y[g].values\n",
+    "    yt = np.log(1 + y / y.max())\n",
+    "    yt = yt / yt.max()\n",
+    "    h = ax[ig].scatter(\n",
+    "        monocle[\"DDRTreeDim1\"],\n",
+    "        monocle[\"DDRTreeDim2\"],\n",
+    "        c=yt,\n",
+    "        s=50,\n",
+    "        alpha=1.0,\n",
+    "        vmin=0,\n",
+    "        vmax=1,\n",
+    "    )\n",
+    "    ax[ig].set_title(g)"
    ]
   },
   {
@@ -387,7 +400,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import BranchedGP, time\n",
     "def PlotGene(label, X, Y, s=3, alpha=1.0, ax=None):\n",
     "    fig = None\n",
     "    if ax is None:\n",
@@ -434,25 +446,39 @@
     }
    ],
    "source": [
-    "def FitGene(g, ns=20): # for quick results subsample data\n",
+    "def FitGene(g, ns=20):  # for quick results subsample data\n",
     "    t = time.time()\n",
-    "    Bsearch = list(np.linspace(0.05, 0.95, 5)) + [1.1]  # set of candidate branching points\n",
-    "    GPy = (Y[g].iloc[::ns].values - Y[g].iloc[::ns].values.mean())[:, None]  # remove mean from gene expression data\n",
-    "    GPt = monocle['StretchedPseudotime'].values[::ns]\n",
-    "    globalBranching = monocle['State'].values[::ns].astype(int)\n",
+    "    Bsearch = list(np.linspace(0.05, 0.95, 5)) + [\n",
+    "        1.1\n",
+    "    ]  # set of candidate branching points\n",
+    "    GPy = (Y[g].iloc[::ns].values - Y[g].iloc[::ns].values.mean())[\n",
+    "        :, None\n",
+    "    ]  # remove mean from gene expression data\n",
+    "    GPt = monocle[\"StretchedPseudotime\"].values[::ns]\n",
+    "    globalBranching = monocle[\"State\"].values[::ns].astype(int)\n",
     "    d = BranchedGP.FitBranchingModel.FitModel(Bsearch, GPt, GPy, globalBranching)\n",
-    "    print(g, 'BGP inference completed in %.1f seconds.' %  (time.time()-t))\n",
+    "    print(g, \"BGP inference completed in %.1f seconds.\" % (time.time() - t))\n",
     "    # plot BGP\n",
-    "    fig,ax=BranchedGP.VBHelperFunctions.PlotBGPFit(GPy, GPt, Bsearch, d, figsize=(10,10))\n",
+    "    fig, ax = BranchedGP.VBHelperFunctions.PlotBGPFit(\n",
+    "        GPy, GPt, Bsearch, d, figsize=(10, 10)\n",
+    "    )\n",
     "    # overplot data\n",
-    "    f, a=PlotGene(monocle['State'].values, monocle['StretchedPseudotime'].values, Y[g].values-Y[g].iloc[::ns].values.mean(), \n",
-    "                  ax=ax[0], s=10, alpha=0.5)\n",
+    "    f, a = PlotGene(\n",
+    "        monocle[\"State\"].values,\n",
+    "        monocle[\"StretchedPseudotime\"].values,\n",
+    "        Y[g].values - Y[g].iloc[::ns].values.mean(),\n",
+    "        ax=ax[0],\n",
+    "        s=10,\n",
+    "        alpha=0.5,\n",
+    "    )\n",
     "    # Calculate Bayes factor of branching vs non-branching\n",
-    "    bf = BranchedGP.VBHelperFunctions.CalculateBranchingEvidence(d)['logBayesFactor']\n",
+    "    bf = BranchedGP.VBHelperFunctions.CalculateBranchingEvidence(d)[\"logBayesFactor\"]\n",
     "\n",
-    "    fig.suptitle('%s log Bayes factor of branching %.1f' % (g, bf))    \n",
+    "    fig.suptitle(\"%s log Bayes factor of branching %.1f\" % (g, bf))\n",
     "    return d, fig, ax\n",
-    "d, fig, ax = FitGene('MPO')"
+    "\n",
+    "\n",
+    "d, fig, ax = FitGene(\"MPO\")"
    ]
   },
   {
@@ -483,7 +509,7 @@
     }
    ],
    "source": [
-    "d_c, fig_c, ax_c = FitGene('CTSG')"
+    "d_c, fig_c, ax_c = FitGene(\"CTSG\")"
    ]
   },
   {

--- a/notebooks/SamplingFromTheModel.ipynb
+++ b/notebooks/SamplingFromTheModel.ipynb
@@ -18,15 +18,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd\n",
-    "import numpy as np\n",
     "import pickle\n",
-    "from matplotlib import pyplot as plt\n",
+    "\n",
     "import gpflow\n",
-    "from BranchedGP import VBHelperFunctions as bplot\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from matplotlib import pyplot as plt\n",
+    "\n",
     "from BranchedGP import BranchingTree as bt\n",
+    "from BranchedGP import VBHelperFunctions as bplot\n",
     "from BranchedGP import branch_kernParamGPflow as bk\n",
-    "plt.style.use('ggplot')\n",
+    "\n",
+    "plt.style.use(\"ggplot\")\n",
     "%matplotlib inline"
    ]
   },
@@ -45,7 +48,9 @@
    "outputs": [],
    "source": [
     "branchingPoint = 0.5\n",
-    "tree = bt.BinaryBranchingTree(0, 10, fDebug=False)  # set to true to print debug messages\n",
+    "tree = bt.BinaryBranchingTree(\n",
+    "    0, 10, fDebug=False\n",
+    ")  # set to true to print debug messages\n",
     "tree.add(None, 1, branchingPoint)  # single branching point\n",
     "(fm, fmb) = tree.GetFunctionBranchTensor()"
    ]

--- a/notebooks/SamplingFromTheModel.py
+++ b/notebooks/SamplingFromTheModel.py
@@ -35,15 +35,18 @@
 # This notebook shows how to sample from a BGP model
 
 # %%
-import pandas as pd
-import numpy as np
 import pickle
-from matplotlib import pyplot as plt
+
 import gpflow
-from BranchedGP import VBHelperFunctions as bplot
+import numpy as np
+import pandas as pd
+from matplotlib import pyplot as plt
+
 from BranchedGP import BranchingTree as bt
+from BranchedGP import VBHelperFunctions as bplot
 from BranchedGP import branch_kernParamGPflow as bk
-plt.style.use('ggplot')
+
+plt.style.use("ggplot")
 # %matplotlib inline
 
 # %% [markdown]
@@ -52,7 +55,9 @@ plt.style.use('ggplot')
 
 # %%
 branchingPoint = 0.5
-tree = bt.BinaryBranchingTree(0, 10, fDebug=False)  # set to true to print debug messages
+tree = bt.BinaryBranchingTree(
+    0, 10, fDebug=False
+)  # set to true to print debug messages
 tree.add(None, 1, branchingPoint)  # single branching point
 (fm, fmb) = tree.GetFunctionBranchTensor()
 

--- a/notebooks/SyntheticData.ipynb
+++ b/notebooks/SyntheticData.ipynb
@@ -20,12 +20,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd\n",
-    "import numpy as np\n",
     "import pickle\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
     "from matplotlib import pyplot as plt\n",
+    "\n",
     "from BranchedGP import VBHelperFunctions as bplot\n",
-    "plt.style.use('ggplot')\n",
+    "\n",
+    "plt.style.use(\"ggplot\")\n",
     "%matplotlib inline"
    ]
   },
@@ -45,7 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "datafile='syntheticdata/synthetic20.csv'\n",
+    "datafile = \"syntheticdata/synthetic20.csv\"\n",
     "data = pd.read_csv(datafile, index_col=[0])\n",
     "G = data.shape[1] - 2  # all data - time columns - state column\n",
     "Y = data.iloc[:, 2:]\n",
@@ -300,13 +303,13 @@
     "f, ax = plt.subplots(5, 8, figsize=(10, 8))\n",
     "ax = ax.flatten()\n",
     "for i in range(G):\n",
-    "    for s in np.unique(data['MonocleState']):\n",
-    "        idxs = (s == data['MonocleState'].values)\n",
-    "        ax[i].scatter(data['Time'].loc[idxs], Y.iloc[:, i].loc[idxs])\n",
+    "    for s in np.unique(data[\"MonocleState\"]):\n",
+    "        idxs = s == data[\"MonocleState\"].values\n",
+    "        ax[i].scatter(data[\"Time\"].loc[idxs], Y.iloc[:, i].loc[idxs])\n",
     "        ax[i].set_title(Y.columns[i])\n",
     "        ax[i].set_yticklabels([])\n",
     "        ax[i].set_xticklabels([])\n",
-    "f.suptitle('Branching genes, location=1.1 indicates no branching')"
+    "f.suptitle(\"Branching genes, location=1.1 indicates no branching\")"
    ]
   },
   {
@@ -316,7 +319,7 @@
    },
    "source": [
     "# Run the BGP model\n",
-    "Run script `runsyntheticData.py` to obtain a pickle file with results. \n",
+    "Run script `runsyntheticData.py` to obtain a pickle file with results.\n",
     "This script can take ~10 to 20 minutes depending on your hardware.\n",
     "It performs a gene-by-gene branch model fitting."
    ]
@@ -326,7 +329,7 @@
    "metadata": {},
    "source": [
     "# Plot BGP posterior fit\n",
-    "Plot posterior fit. "
+    "Plot posterior fit."
    ]
   },
   {
@@ -337,7 +340,7 @@
    },
    "outputs": [],
    "source": [
-    "r = pickle.load(open('syntheticdata/syntheticDataRun.p', \"rb\"))"
+    "r = pickle.load(open(\"syntheticdata/syntheticDataRun.p\", \"rb\"))"
    ]
   },
   {
@@ -399,11 +402,11 @@
     "# plot fit for a gene\n",
     "g = 0\n",
     "GPy = Y.iloc[:, g][:, None]\n",
-    "GPt = data['Time'].values\n",
-    "globalBranching = data['MonocleState'].values.astype(int)\n",
-    "bmode = r['Bsearch'][np.argmax(r['gpmodels'][g]['loglik'])]\n",
-    "print('True branching time', trueBranchingTimes[g], 'BGP Maximum at b=%.2f' % bmode)\n",
-    "_=bplot.PlotBGPFit(GPy, GPt, r['Bsearch'], r['gpmodels'][g])"
+    "GPt = data[\"Time\"].values\n",
+    "globalBranching = data[\"MonocleState\"].values.astype(int)\n",
+    "bmode = r[\"Bsearch\"][np.argmax(r[\"gpmodels\"][g][\"loglik\"])]\n",
+    "print(\"True branching time\", trueBranchingTimes[g], \"BGP Maximum at b=%.2f\" % bmode)\n",
+    "_ = bplot.PlotBGPFit(GPy, GPt, r[\"Bsearch\"], r[\"gpmodels\"][g])"
    ]
   },
   {
@@ -434,11 +437,20 @@
    ],
    "source": [
     "g = 0\n",
-    "bmode = r['Bsearch'][np.argmax(r['gpmodels'][g]['loglik'])]\n",
-    "pred = r['gpmodels'][g]['prediction']  # prediction object from GP\n",
-    "_=bplot.plotBranchModel(bmode, GPt, GPy, pred['xtest'], pred['mu'], pred['var'],\n",
-    "                     r['gpmodels'][g]['Phi'], fPlotPhi=True, fColorBar=True,\n",
-    "                       fPlotVar = True)"
+    "bmode = r[\"Bsearch\"][np.argmax(r[\"gpmodels\"][g][\"loglik\"])]\n",
+    "pred = r[\"gpmodels\"][g][\"prediction\"]  # prediction object from GP\n",
+    "_ = bplot.plotBranchModel(\n",
+    "    bmode,\n",
+    "    GPt,\n",
+    "    GPy,\n",
+    "    pred[\"xtest\"],\n",
+    "    pred[\"mu\"],\n",
+    "    pred[\"var\"],\n",
+    "    r[\"gpmodels\"][g][\"Phi\"],\n",
+    "    fPlotPhi=True,\n",
+    "    fColorBar=True,\n",
+    "    fPlotVar=True,\n",
+    ")"
    ]
   },
   {
@@ -470,9 +482,9 @@
    "source": [
     "fs, ax = plt.subplots(1, 1, figsize=(5, 5))\n",
     "for g in range(G):\n",
-    "    bmode = r['Bsearch'][np.argmax(r['gpmodels'][g]['loglik'])]\n",
-    "    ax.scatter(bmode, g, s=100, color='b')  # BGP mode\n",
-    "    ax.scatter(trueBranchingTimes[g]+0.05, g, s=100, color='k')  # True"
+    "    bmode = r[\"Bsearch\"][np.argmax(r[\"gpmodels\"][g][\"loglik\"])]\n",
+    "    ax.scatter(bmode, g, s=100, color=\"b\")  # BGP mode\n",
+    "    ax.scatter(trueBranchingTimes[g] + 0.05, g, s=100, color=\"k\")  # True"
    ]
   },
   {

--- a/notebooks/SyntheticData.py
+++ b/notebooks/SyntheticData.py
@@ -37,12 +37,15 @@
 # This notebook shows how to build a BGP model and plot the posterior model fit and posterior branching times.
 
 # %%
-import pandas as pd
-import numpy as np
 import pickle
+
+import numpy as np
+import pandas as pd
 from matplotlib import pyplot as plt
+
 from BranchedGP import VBHelperFunctions as bplot
-plt.style.use('ggplot')
+
+plt.style.use("ggplot")
 # %matplotlib inline
 
 # %% [markdown]
@@ -52,7 +55,7 @@ plt.style.use('ggplot')
 # 1. All other columns are the 40 genes. The first 10 branch early, then 20 branch late and 10 do not branch.
 
 # %%
-datafile='syntheticdata/synthetic20.csv'
+datafile = "syntheticdata/synthetic20.csv"
 data = pd.read_csv(datafile, index_col=[0])
 G = data.shape[1] - 2  # all data - time columns - state column
 Y = data.iloc[:, 2:]
@@ -68,26 +71,26 @@ data.head()
 f, ax = plt.subplots(5, 8, figsize=(10, 8))
 ax = ax.flatten()
 for i in range(G):
-    for s in np.unique(data['MonocleState']):
-        idxs = (s == data['MonocleState'].values)
-        ax[i].scatter(data['Time'].loc[idxs], Y.iloc[:, i].loc[idxs])
+    for s in np.unique(data["MonocleState"]):
+        idxs = s == data["MonocleState"].values
+        ax[i].scatter(data["Time"].loc[idxs], Y.iloc[:, i].loc[idxs])
         ax[i].set_title(Y.columns[i])
         ax[i].set_yticklabels([])
         ax[i].set_xticklabels([])
-f.suptitle('Branching genes, location=1.1 indicates no branching')
+f.suptitle("Branching genes, location=1.1 indicates no branching")
 
 # %% [markdown]
 # # Run the BGP model
-# Run script `runsyntheticData.py` to obtain a pickle file with results. 
+# Run script `runsyntheticData.py` to obtain a pickle file with results.
 # This script can take ~10 to 20 minutes depending on your hardware.
 # It performs a gene-by-gene branch model fitting.
 
 # %% [markdown]
 # # Plot BGP posterior fit
-# Plot posterior fit. 
+# Plot posterior fit.
 
 # %%
-r = pickle.load(open('syntheticdata/syntheticDataRun.p', "rb"))
+r = pickle.load(open("syntheticdata/syntheticDataRun.p", "rb"))
 
 # %%
 r.keys()
@@ -96,11 +99,11 @@ r.keys()
 # plot fit for a gene
 g = 0
 GPy = Y.iloc[:, g][:, None]
-GPt = data['Time'].values
-globalBranching = data['MonocleState'].values.astype(int)
-bmode = r['Bsearch'][np.argmax(r['gpmodels'][g]['loglik'])]
-print('True branching time', trueBranchingTimes[g], 'BGP Maximum at b=%.2f' % bmode)
-_=bplot.PlotBGPFit(GPy, GPt, r['Bsearch'], r['gpmodels'][g])
+GPt = data["Time"].values
+globalBranching = data["MonocleState"].values.astype(int)
+bmode = r["Bsearch"][np.argmax(r["gpmodels"][g]["loglik"])]
+print("True branching time", trueBranchingTimes[g], "BGP Maximum at b=%.2f" % bmode)
+_ = bplot.PlotBGPFit(GPy, GPt, r["Bsearch"], r["gpmodels"][g])
 
 # %% [markdown]
 # We can also plot with the predictive uncertainty of the GP.
@@ -108,11 +111,20 @@ _=bplot.PlotBGPFit(GPy, GPt, r['Bsearch'], r['gpmodels'][g])
 
 # %%
 g = 0
-bmode = r['Bsearch'][np.argmax(r['gpmodels'][g]['loglik'])]
-pred = r['gpmodels'][g]['prediction']  # prediction object from GP
-_=bplot.plotBranchModel(bmode, GPt, GPy, pred['xtest'], pred['mu'], pred['var'],
-                     r['gpmodels'][g]['Phi'], fPlotPhi=True, fColorBar=True,
-                       fPlotVar = True)
+bmode = r["Bsearch"][np.argmax(r["gpmodels"][g]["loglik"])]
+pred = r["gpmodels"][g]["prediction"]  # prediction object from GP
+_ = bplot.plotBranchModel(
+    bmode,
+    GPt,
+    GPy,
+    pred["xtest"],
+    pred["mu"],
+    pred["var"],
+    r["gpmodels"][g]["Phi"],
+    fPlotPhi=True,
+    fColorBar=True,
+    fPlotVar=True,
+)
 
 # %% [markdown]
 # # Plot posterior
@@ -121,8 +133,8 @@ _=bplot.plotBranchModel(bmode, GPt, GPy, pred['xtest'], pred['mu'], pred['var'],
 # %%
 fs, ax = plt.subplots(1, 1, figsize=(5, 5))
 for g in range(G):
-    bmode = r['Bsearch'][np.argmax(r['gpmodels'][g]['loglik'])]
-    ax.scatter(bmode, g, s=100, color='b')  # BGP mode
-    ax.scatter(trueBranchingTimes[g]+0.05, g, s=100, color='k')  # True
+    bmode = r["Bsearch"][np.argmax(r["gpmodels"][g]["loglik"])]
+    ax.scatter(bmode, g, s=100, color="b")  # BGP mode
+    ax.scatter(trueBranchingTimes[g] + 0.05, g, s=100, color="k")  # True
 
 # %%

--- a/notebooks/runsynteticData.py
+++ b/notebooks/runsynteticData.py
@@ -1,21 +1,27 @@
-'''
+"""
 Run BGP on synthetic data. Will save results to pickle file which
 can then be examined in notebook.
-'''
+"""
 import pickle
-import pandas as pd
-import numpy as np
 import time
+
+import numpy as np
+import pandas as pd
+
 import BranchedGP
 
-datafile = 'syntheticdata/synthetic20.csv'
+datafile = "syntheticdata/synthetic20.csv"
 data = pd.read_csv(datafile, index_col=[0])
 G = data.shape[1] - 2  # all data - time columns - state column
 Y = data.iloc[:, 2:]
 for i in range(G):
-    assert 'Y' == Y.columns[i][:1], 'Bad gene column name %s. Should start with Y.' % Y.columns[i]
+    assert "Y" == Y.columns[i][:1], (
+        "Bad gene column name %s. Should start with Y." % Y.columns[i]
+    )
 trueBranchingTimes = np.array([float(Y.columns[i][-3:]) for i in range(G)])
-assert np.all(trueBranchingTimes>0) and np.all(trueBranchingTimes <= 1.1), 'Branching time should be in [0,1.1]'
+assert np.all(trueBranchingTimes > 0) and np.all(
+    trueBranchingTimes <= 1.1
+), "Branching time should be in [0,1.1]"
 
 
 M = 10  # number of inducing points. Increase for better accuracy but at increased computational cose.
@@ -26,12 +32,23 @@ Bsearch = [0.1, 0.2, 0.3, 0.5, 0.8, 1.1]  # set of candidate branching points
 for g in range(G):
     t = time.time()
     GPy = Y.iloc[:, g][:, None]
-    GPt = data['Time'].values
-    globalBranching = data['MonocleState'].values.astype(int)
-    gpmodels.append(BranchedGP.FitBranchingModel.FitModel(Bsearch, GPt, GPy, globalBranching, maxiter=maxiter, M=M))
-    bmode = Bsearch[np.argmax(gpmodels[g]['loglik'])]
-    print(trueBranchingTimes[g], 'BGP Maximum at b=%.2f' % bmode, 'inference completed in %.1f seconds.' % (time.time()-t))
-    _ = gpmodels[g].pop('model')  # remove model which cannot be pickled
-pickle.dump({'gpmodels': gpmodels, 'Bsearch': Bsearch, 'M': M, 'maxiter': maxiter}, open('syntheticdata/syntheticDataRun.p', "wb"))
+    GPt = data["Time"].values
+    globalBranching = data["MonocleState"].values.astype(int)
+    gpmodels.append(
+        BranchedGP.FitBranchingModel.FitModel(
+            Bsearch, GPt, GPy, globalBranching, maxiter=maxiter, M=M
+        )
+    )
+    bmode = Bsearch[np.argmax(gpmodels[g]["loglik"])]
+    print(
+        trueBranchingTimes[g],
+        "BGP Maximum at b=%.2f" % bmode,
+        "inference completed in %.1f seconds." % (time.time() - t),
+    )
+    _ = gpmodels[g].pop("model")  # remove model which cannot be pickled
+pickle.dump(
+    {"gpmodels": gpmodels, "Bsearch": Bsearch, "M": M, "maxiter": maxiter},
+    open("syntheticdata/syntheticDataRun.p", "wb"),
+)
 tend = time.time()
-print('Done - total time %.1f secs' % (tend-tallstart))
+print("Done - total time %.1f secs" % (tend - tallstart))

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,16 +1,19 @@
 absl-py==0.10.0
 aiohttp==3.6.2
+appdirs==1.4.4
 argon2-cffi==20.1.0
 astunparse==1.6.3
 async-generator==1.10
 async-timeout==3.0.1
 attrs==20.2.0
 backcall==0.2.0
+black==20.8b1
 bleach==3.2.1
 cachetools==4.1.1
 certifi==2020.6.20
 cffi==1.14.3
 chardet==3.0.4
+click==7.1.2
 cloudpickle==1.6.0
 cycler==0.10.0
 dataclasses==0.6
@@ -30,6 +33,7 @@ ipykernel==5.3.4
 ipython==7.18.1
 ipython-genutils==0.2.0
 ipywidgets==7.5.1
+isort==5.6.4
 jedi==0.17.2
 Jinja2==2.11.2
 jsonschema==3.2.0
@@ -48,6 +52,7 @@ matplotlib==3.3.2
 mistune==0.8.4
 multidict==4.7.6
 multipledispatch==0.6.0
+mypy-extensions==0.4.3
 nbclient==0.5.0
 nbconvert==6.0.7
 nbformat==5.0.7
@@ -61,6 +66,7 @@ packaging==20.4
 pandas==1.1.2
 pandocfilters==1.4.2
 parso==0.7.1
+pathspec==0.8.0
 pexpect==4.8.0
 pickleshare==0.7.5
 Pillow==7.2.0
@@ -80,6 +86,7 @@ PyYAML==5.3.1
 pyzmq==19.0.2
 qtconsole==4.7.7
 QtPy==1.9.0
+regex==2020.10.28
 requests==2.24.0
 requests-oauthlib==1.3.0
 rsa==4.6
@@ -98,6 +105,7 @@ testpath==0.4.4
 toml==0.10.2
 tornado==6.0.4
 traitlets==5.0.4
+typed-ast==1.4.1
 typing-extensions==3.7.4.3
 urllib3==1.25.10
 wcwidth==0.2.5

--- a/testing/testAssignment.py
+++ b/testing/testAssignment.py
@@ -1,14 +1,14 @@
 # Generic libraries
+import unittest
+
 import gpflow
 import numpy as np
 import tensorflow as tf
-import unittest
 
 # Branching files
-from BranchedGP import VBHelperFunctions
 from BranchedGP import BranchingTree as bt
+from BranchedGP import VBHelperFunctions, assigngp_dense
 from BranchedGP import branch_kernParamGPflow as bk
-from BranchedGP import assigngp_dense
 
 
 def InitKernParams(ms):
@@ -18,9 +18,8 @@ def InitKernParams(ms):
 
 
 class TestSparseVariational(unittest.TestCase):
-
     def test(self):
-        np.set_printoptions(suppress=True,  precision=5)
+        np.set_printoptions(suppress=True, precision=5)
         seed = 43
         np.random.seed(seed=seed)  # easy peasy reproducibeasy
         tf.random.set_seed(seed)
@@ -28,7 +27,7 @@ class TestSparseVariational(unittest.TestCase):
         N = 20
         t = np.linspace(0, 1, N)
         print(t)
-        trueB = np.ones((1, 1))*0.5
+        trueB = np.ones((1, 1)) * 0.5
         Y = np.zeros((N, 1))
         idx = np.nonzero(t > 0.5)[0]
         idxA = idx[::2]
@@ -42,53 +41,79 @@ class TestSparseVariational(unittest.TestCase):
         tree = bt.BinaryBranchingTree(0, 1, fDebug=False)
         tree.add(None, 1, trueB)
         assert tree.getRoot().val == trueB
-        assert  tree.getRoot().idB == 1
+        assert tree.getRoot().idB == 1
         (fm, _) = tree.GetFunctionBranchTensor()
         XExpanded, indices, _ = VBHelperFunctions.GetFunctionIndexListGeneral(t)
         # Create model
-        Kbranch = bk.BranchKernelParam(gpflow.kernels.Matern32(), fm, b=trueB.copy()) + gpflow.kernels.White()
-        Kbranch.kernels[1].variance.assign(1e-6)  # controls the discontinuity magnitude, the gap at the branching point
+        Kbranch = (
+            bk.BranchKernelParam(gpflow.kernels.Matern32(), fm, b=trueB.copy())
+            + gpflow.kernels.White()
+        )
+        Kbranch.kernels[1].variance.assign(
+            1e-6
+        )  # controls the discontinuity magnitude, the gap at the branching point
         gpflow.set_trainable(Kbranch.kernels[1].variance, False)  # jitter for numerics
         # Create model
-        phiPrior = np.ones((N, 2))*0.5  # dont know anything
-        phiInitial = np.ones((N, 2))*0.5  # dont know anything
+        phiPrior = np.ones((N, 2)) * 0.5  # dont know anything
+        phiInitial = np.ones((N, 2)) * 0.5  # dont know anything
         phiInitial[:, 0] = np.random.rand(N)
-        phiInitial[:, 1] = 1-phiInitial[:, 0]
-        m = assigngp_dense.AssignGP(t, XExpanded, Y, Kbranch, indices,
-                                    Kbranch.kernels[0].Bv, phiPrior=phiPrior, phiInitial=phiInitial)
+        phiInitial[:, 1] = 1 - phiInitial[:, 0]
+        m = assigngp_dense.AssignGP(
+            t,
+            XExpanded,
+            Y,
+            Kbranch,
+            indices,
+            Kbranch.kernels[0].Bv,
+            phiPrior=phiPrior,
+            phiInitial=phiInitial,
+        )
         InitKernParams(m)
         gpflow.set_trainable(m.likelihood.variance, False)
-        print('Model before initialisation\n', m, '\n===========================')
+        print("Model before initialisation\n", m, "\n===========================")
         opt = gpflow.optimizers.Scipy()
-        opt.minimize(m.training_loss, variables=m.trainable_variables,
-                     options=dict(disp=True, maxiter=100))
+        opt.minimize(
+            m.training_loss,
+            variables=m.trainable_variables,
+            options=dict(disp=True, maxiter=100),
+        )
         gpflow.set_trainable(m.likelihood.variance, True)
-        opt.minimize(m.training_loss, variables=m.trainable_variables,
-                     options=dict(disp=True, maxiter=100))
-        print('Model after initialisation\n', m, '\n===========================')
+        opt.minimize(
+            m.training_loss,
+            variables=m.trainable_variables,
+            options=dict(disp=True, maxiter=100),
+        )
+        print("Model after initialisation\n", m, "\n===========================")
         ttestl, mul, varl = VBHelperFunctions.predictBranchingModel(m)
         _, _, covl = VBHelperFunctions.predictBranchingModel(m, full_cov=True)
-        
-        assert len(varl) == 3, 'Must have 3 predictions for 3 functions'
-        assert np.all(varl[0] > 0), 'neg variances for variance function 0'
-        assert np.all(varl[1] > 0), 'neg variances for variance function 1'
-        assert np.all(varl[2] > 0), 'neg variances for variance function 2'
+
+        assert len(varl) == 3, "Must have 3 predictions for 3 functions"
+        assert np.all(varl[0] > 0), "neg variances for variance function 0"
+        assert np.all(varl[1] > 0), "neg variances for variance function 1"
+        assert np.all(varl[2] > 0), "neg variances for variance function 2"
         PhiOptimised = m.GetPhi()
-        print('phiPrior', phiPrior)
-        print('PhiOptimised', PhiOptimised)
-        assert np.allclose(PhiOptimised[idxA, 2], 1),  'PhiOptimised idxA=%s' % str(PhiOptimised[idxA, :])
-        assert np.allclose(PhiOptimised[idxB, 1], 1),  'PhiOptimised idxB=%s' % str(PhiOptimised[idxB, :])
+        print("phiPrior", phiPrior)
+        print("PhiOptimised", PhiOptimised)
+        assert np.allclose(PhiOptimised[idxA, 2], 1), "PhiOptimised idxA=%s" % str(
+            PhiOptimised[idxA, :]
+        )
+        assert np.allclose(PhiOptimised[idxB, 1], 1), "PhiOptimised idxB=%s" % str(
+            PhiOptimised[idxB, :]
+        )
         # reset model and test informative KL prior
         m.UpdateBranchingPoint(Kbranch.kernels[0].Bv, phiInitial)  # reset initial phi
         InitKernParams(m)
         ll_flatprior = m.log_posterior_density()
-        phiInfPrior = np.ones((N, 2))*0.5  # dont know anything
+        phiInfPrior = np.ones((N, 2)) * 0.5  # dont know anything
         phiInfPrior[-1, :] = [0.99, 0.01]
         # phiInfPrior[-2, :] = [0.01, 0.99]
         m.UpdateBranchingPoint(Kbranch.kernels[0].Bv, phiInitial, prior=phiInfPrior)
         ll_betterprior = m.log_posterior_density()
-        assert ll_betterprior > ll_flatprior, '%f <> %f' % (ll_betterprior, ll_flatprior)
+        assert ll_betterprior > ll_flatprior, "%f <> %f" % (
+            ll_betterprior,
+            ll_flatprior,
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/testing/testKL.py
+++ b/testing/testKL.py
@@ -1,21 +1,21 @@
 # Generic libraries
+import unittest
+
 import gpflow
 import numpy as np
 import tensorflow as tf
-import unittest
-# Branching files
-from BranchedGP import VBHelperFunctions
-from BranchedGP import BranchingTree as bt
-from BranchedGP import branch_kernParamGPflow as bk
-from BranchedGP import assigngp_dense
-from BranchedGP import FitBranchingModel
-
 from gpflow import set_trainable
+
+# Branching files
+from BranchedGP import BranchingTree as bt
+from BranchedGP import FitBranchingModel, VBHelperFunctions, assigngp_dense
+from BranchedGP import branch_kernParamGPflow as bk
+
 
 class TestKL(unittest.TestCase):
     def test(self):
         fDebug = True  # Enable debugging output - tensorflow print ops
-        np.set_printoptions(suppress=True,  precision=5)
+        np.set_printoptions(suppress=True, precision=5)
         seed = 43
         np.random.seed(seed=seed)  # easy peasy reproducibeasy
         tf.random.set_seed(seed)
@@ -23,9 +23,9 @@ class TestKL(unittest.TestCase):
         N = 20
         t = np.linspace(0, 1, N)
         print(t)
-        trueB = np.ones((1, 1))*0.5
+        trueB = np.ones((1, 1)) * 0.5
         Y = np.zeros((N, 1))
-        idx = np.nonzero(t>0.5)[0]
+        idx = np.nonzero(t > 0.5)[0]
         idxA = idx[::2]
         idxB = idx[1::2]
         print(idx)
@@ -38,29 +38,58 @@ class TestKL(unittest.TestCase):
         globalBranchingLabels[5::2] = 3
 
         XExpanded, indices, _ = VBHelperFunctions.GetFunctionIndexListGeneral(t)
-        phiInitial, phiPrior = FitBranchingModel.GetInitialConditionsAndPrior(globalBranchingLabels, 0.51, False)
-        ptb = np.min([np.min(t[globalBranchingLabels == 2]), np.min(t[globalBranchingLabels == 3])])
+        phiInitial, phiPrior = FitBranchingModel.GetInitialConditionsAndPrior(
+            globalBranchingLabels, 0.51, False
+        )
+        ptb = np.min(
+            [
+                np.min(t[globalBranchingLabels == 2]),
+                np.min(t[globalBranchingLabels == 3]),
+            ]
+        )
         tree = bt.BinaryBranchingTree(0, 1, fDebug=False)
         tree.add(None, 1, np.ones((1, 1)) * ptb)  # B can be anything here
         (fm1, _) = tree.GetFunctionBranchTensor()
 
         # Look at kernels
-        fDebug=True
-        Kbranch1 = bk.BranchKernelParam(gpflow.kernels.Matern32(), fm1, b=np.ones((1, 1)) * ptb, fDebug=fDebug)
+        fDebug = True
+        Kbranch1 = bk.BranchKernelParam(
+            gpflow.kernels.Matern32(), fm1, b=np.ones((1, 1)) * ptb, fDebug=fDebug
+        )
         K1 = Kbranch1.K(XExpanded, XExpanded)
 
-        Kbranch2 = bk.BranchKernelParam(gpflow.kernels.Matern32(), fm1, b=np.ones((1, 1)) * 0.20, fDebug=fDebug)
+        Kbranch2 = bk.BranchKernelParam(
+            gpflow.kernels.Matern32(), fm1, b=np.ones((1, 1)) * 0.20, fDebug=fDebug
+        )
         K2 = Kbranch2.K(XExpanded, XExpanded)
 
-        Kbranch3 = bk.BranchKernelParam(gpflow.kernels.Matern32(), fm1, b=np.ones((1, 1)) * 0.22, fDebug=fDebug)
+        Kbranch3 = bk.BranchKernelParam(
+            gpflow.kernels.Matern32(), fm1, b=np.ones((1, 1)) * 0.22, fDebug=fDebug
+        )
         K3 = Kbranch3.K(XExpanded, XExpanded)
 
         # Look at model
-        kb = bk.BranchKernelParam(gpflow.kernels.Matern32(), fm1, b=np.zeros((1, 1))) + gpflow.kernels.White()
-        kb.kernels[1].variance.assign(1e-6)  # controls the discontinuity magnitude, the gap at the branching point
+        kb = (
+            bk.BranchKernelParam(gpflow.kernels.Matern32(), fm1, b=np.zeros((1, 1)))
+            + gpflow.kernels.White()
+        )
+        kb.kernels[1].variance.assign(
+            1e-6
+        )  # controls the discontinuity magnitude, the gap at the branching point
         set_trainable(kb.kernels[1].variance, False)  # jitter for numerics
         # m = assigngp_dense.AssignGP(t, XExpanded, Y, kb, indices, np.ones((1, 1)), phiInitial=phiInitial, phiPrior=phiPrior)
-        m = assigngp_dense.AssignGP(t, XExpanded, Y, kb, indices, np.ones((1, 1)), phiInitial=phiInitial, phiPrior=phiPrior, KConst=K1, fDebug=True)
+        m = assigngp_dense.AssignGP(
+            t,
+            XExpanded,
+            Y,
+            kb,
+            indices,
+            np.ones((1, 1)),
+            phiInitial=phiInitial,
+            phiPrior=phiPrior,
+            KConst=K1,
+            fDebug=True,
+        )
 
         m.UpdateBranchingPoint(np.ones((1, 1)) * ptb, phiInitial.copy())
         ptbLL = m.log_posterior_density()
@@ -72,5 +101,6 @@ class TestKL(unittest.TestCase):
         assert eLL < ptbLL
         assert np.allclose(ptbLL, lll)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/testing/testKernel.py
+++ b/testing/testKernel.py
@@ -1,51 +1,69 @@
 # Generic libraries
+import unittest
+
 import gpflow
 import numpy as np
-import unittest
+
 # Branching files
 from BranchedGP import BranchingTree as bt
 from BranchedGP import branch_kernParamGPflow as bk
 
+
 class TestKernelSampling(unittest.TestCase):
     def test(self):
         N = 3  # how many points per function
-        tree = bt.BinaryBranchingTree(0, 10, fDebug=False)  # set to true to print debug messages
+        tree = bt.BinaryBranchingTree(
+            0, 10, fDebug=False
+        )  # set to true to print debug messages
         tree.add(None, 1, 0.5)  # single branching point
         (fm, fmb) = tree.GetFunctionBranchTensor()
         # print fmb
 
         tree.printTree()
-        print('fm', fm)
+        print("fm", fm)
         # print fmb
         t = np.linspace(0.01, 1, 10)
-        (XForKernel, indicesBranch, Xtrue) = tree.GetFunctionIndexList(t, fReturnXtrue=True)
+        (XForKernel, indicesBranch, Xtrue) = tree.GetFunctionIndexList(
+            t, fReturnXtrue=True
+        )
         # GP flow kernel
         Bvalues = np.expand_dims(np.asarray(tree.GetBranchValues()), 1)
-        KbranchParam = bk.BranchKernelParam(gpflow.kernels.SquaredExponential(), fm, b=Bvalues)
+        KbranchParam = bk.BranchKernelParam(
+            gpflow.kernels.SquaredExponential(), fm, b=Bvalues
+        )
         KbranchParam.kern.lengthscales.assign(2)
         KbranchParam.kern.variance.assign(1)
 
         K = KbranchParam.K(Xtrue, Xtrue)
         assert KbranchParam.Bv == 0.5
 
-
-        samples, L, K = bk.SampleKernel(KbranchParam, XForKernel, D=1, tol=1e-6, retChol=True)
-        samples2 = bk.SampleKernel(KbranchParam, XForKernel, D=1, tol=1e-6, retChol=False)
+        samples, L, K = bk.SampleKernel(
+            KbranchParam, XForKernel, D=1, tol=1e-6, retChol=True
+        )
+        samples2 = bk.SampleKernel(
+            KbranchParam, XForKernel, D=1, tol=1e-6, retChol=False
+        )
 
         # Also try the independent kernel
         indKernel = bk.IndKern(gpflow.kernels.SquaredExponential())
-        samples3, L, K = bk.SampleKernel(indKernel, XForKernel, D=1, tol=1e-6, retChol=True)
+        samples3, L, K = bk.SampleKernel(
+            indKernel, XForKernel, D=1, tol=1e-6, retChol=True
+        )
 
         samples4 = KbranchParam.SampleKernel(XForKernel, b=Bvalues)
 
         XAssignments = bk.GetFunctionIndexSample(t)  # assign to either branch randomly
         XAssignments[XAssignments[:, 0] <= tree.GetBranchValues(), 1] = 1
-        samples5 = KbranchParam.SampleKernelFromTree(XAssignments, b=tree.GetBranchValues())
+        samples5 = KbranchParam.SampleKernelFromTree(
+            XAssignments, b=tree.GetBranchValues()
+        )
 
         # if you want to plot
         # from matplotlib import pyplot as plt
         # plt.ion()
         # plt.scatter(XForKernel[:, 0], samples, s=200)
         #
-if __name__ == '__main__':
+
+
+if __name__ == "__main__":
     unittest.main()

--- a/testing/testObjective.py
+++ b/testing/testObjective.py
@@ -1,18 +1,20 @@
 # Generic libraries
+import unittest
+
 import gpflow
 import numpy as np
 import tensorflow as tf
-import unittest
+
 # Branching files
-from BranchedGP import VBHelperFunctions
-from BranchedGP import FitBranchingModel
+from BranchedGP import FitBranchingModel, VBHelperFunctions
+
 
 class TestObjectiveMin(unittest.TestCase):
     def test(self):
         # Test VB bound is valid objective function.
 
         fDebug = True  # Enable debugging output - tensorflow print ops
-        np.set_printoptions(suppress=True,  precision=5)
+        np.set_printoptions(suppress=True, precision=5)
         seed = 43
         np.random.seed(seed=seed)  # easy peasy reproducibeasy
         tf.random.set_seed(seed)
@@ -20,7 +22,7 @@ class TestObjectiveMin(unittest.TestCase):
         N = 20
         t = np.linspace(0, 1, N)
         print(t)
-        trueB = np.ones((1, 1))*0.4
+        trueB = np.ones((1, 1)) * 0.4
         Y = np.zeros((N, 1))
         idx = np.nonzero(t > 0.5)[0]
         idxA = idx[::2]
@@ -32,43 +34,71 @@ class TestObjectiveMin(unittest.TestCase):
         Y[idxB, 0] = -2 * t[idxB]
         # Create global branches
         globalBranchingLabels = np.ones(N)
-        istart = np.min(np.flatnonzero(t>0.5))
+        istart = np.min(np.flatnonzero(t > 0.5))
         globalBranchingLabels[istart::2] = 2
-        globalBranchingLabels[(istart+1)::2] = 3
-        ptb = np.min([np.min(t[globalBranchingLabels == 2]), np.min(t[globalBranchingLabels == 3])])
+        globalBranchingLabels[(istart + 1) :: 2] = 3
+        ptb = np.min(
+            [
+                np.min(t[globalBranchingLabels == 2]),
+                np.min(t[globalBranchingLabels == 3]),
+            ]
+        )
         # Do a search very close to globel branching time
-        BgridSearch = [ptb, 0.1, 0.4, np.round(ptb,1), np.round(ptb+0.01,2), 0.7, 1.1]
-        d = FitBranchingModel.FitModel(BgridSearch, t, Y, globalBranchingLabels,
-                                                  maxiter=50, priorConfidence=0.65, kervar=1., kerlen=1., likvar=0.01)
-        iw = np.argmax(d['loglik'])
+        BgridSearch = [
+            ptb,
+            0.1,
+            0.4,
+            np.round(ptb, 1),
+            np.round(ptb + 0.01, 2),
+            0.7,
+            1.1,
+        ]
+        d = FitBranchingModel.FitModel(
+            BgridSearch,
+            t,
+            Y,
+            globalBranchingLabels,
+            maxiter=50,
+            priorConfidence=0.65,
+            kervar=1.0,
+            kerlen=1.0,
+            likvar=0.01,
+        )
+        iw = np.argmax(d["loglik"])
         Bmode = BgridSearch[iw]
         # Check winner is the truth
         assignment = np.ones(N)
-        assignment[d['Phi'][:, 1] > 0.5] = 2
-        assignment[d['Phi'][:, 1] < 0.5] = 3
-        assignment[d['Phi'][:, 0] > 0.99] = 1
+        assignment[d["Phi"][:, 1] > 0.5] = 2
+        assignment[d["Phi"][:, 1] < 0.5] = 3
+        assignment[d["Phi"][:, 0] > 0.99] = 1
 
         altassignment = np.ones(N)
-        altassignment[d['Phi'][:, 1] > 0.5] = 3
-        altassignment[d['Phi'][:, 1] < 0.5] = 2
-        altassignment[d['Phi'][:, 0] > 0.99] = 1
+        altassignment[d["Phi"][:, 1] > 0.5] = 3
+        altassignment[d["Phi"][:, 1] < 0.5] = 2
+        altassignment[d["Phi"][:, 0] > 0.99] = 1
 
         trueassignment = np.ones(N)
         trueassignment[idxA] = 2
         trueassignment[idxB] = 3
 
-        acc = np.max([(trueassignment == assignment).sum(), (trueassignment == altassignment).sum()])
+        acc = np.max(
+            [
+                (trueassignment == assignment).sum(),
+                (trueassignment == altassignment).sum(),
+            ]
+        )
 
-        assert Bmode == trueB, 'Picked B=%f' % Bmode
-        assert acc >= N-2, 'Got accuracy of %g' % acc
+        assert Bmode == trueB, "Picked B=%f" % Bmode
+        assert acc >= N - 2, "Got accuracy of %g" % acc
 
         # Check objective monotone
-        iobjSort = np.argsort(d['loglik'])
-        assert iobjSort.size == 7, 'We must have added two point, the ptb and 1.1'
-        print(np.array(BgridSearch)[iobjSort], d['loglik'][iobjSort])
+        iobjSort = np.argsort(d["loglik"])
+        assert iobjSort.size == 7, "We must have added two point, the ptb and 1.1"
+        print(np.array(BgridSearch)[iobjSort], d["loglik"][iobjSort])
         assert np.all(iobjSort == np.array([6, 5, 4, 0, 3, 1, 2]))
         idx = np.array([6, 5, 4, 0, 3, 1, 2])
-        print('We want', (np.array(BgridSearch))[idx])
+        print("We want", (np.array(BgridSearch))[idx])
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/testing/testSamplingAndPlotting.py
+++ b/testing/testSamplingAndPlotting.py
@@ -1,30 +1,39 @@
-import pandas as pd
-import numpy as np
 import pickle
-from matplotlib import pyplot as plt
-import gpflow
-from BranchedGP import VBHelperFunctions as bplot
-from BranchedGP import BranchingTree as bt
-from BranchedGP import branch_kernParamGPflow as bk
 import unittest
-from BranchedGP import FitBranchingModel
+
+import gpflow
+import numpy as np
+import pandas as pd
 import tensorflow as tf
+from matplotlib import pyplot as plt
+
+from BranchedGP import BranchingTree as bt
+from BranchedGP import FitBranchingModel
+from BranchedGP import VBHelperFunctions as bplot
+from BranchedGP import branch_kernParamGPflow as bk
+
 
 class TestSamplingAndPlotting(unittest.TestCase):
     def test(self):
         branchingPoint = 0.5
-        tree = bt.BinaryBranchingTree(0, 10, fDebug=False)  # set to true to print debug messages
+        tree = bt.BinaryBranchingTree(
+            0, 10, fDebug=False
+        )  # set to true to print debug messages
         tree.add(None, 1, branchingPoint)  # single branching point
         (fm, fmb) = tree.GetFunctionBranchTensor()
         # Specify where to evaluate the kernel
         t = np.linspace(0.01, 1, 60)
-        (XForKernel, indicesBranch, Xtrue) = tree.GetFunctionIndexList(t, fReturnXtrue=True)
+        (XForKernel, indicesBranch, Xtrue) = tree.GetFunctionIndexList(
+            t, fReturnXtrue=True
+        )
         # Specify the kernel and its hyperparameters
         # These determine how smooth and variable the branching functions are
         Bvalues = np.expand_dims(np.asarray(tree.GetBranchValues()), 1)
-        KbranchParam = bk.BranchKernelParam(gpflow.kernels.SquaredExponential(), fm, b=Bvalues)
-        KbranchParam.kern.lengthscales.assign(2.)
-        KbranchParam.kern.variance.assign(1.)
+        KbranchParam = bk.BranchKernelParam(
+            gpflow.kernels.SquaredExponential(), fm, b=Bvalues
+        )
+        KbranchParam.kern.lengthscales.assign(2.0)
+        KbranchParam.kern.variance.assign(1.0)
         # Sample the kernel
         samples = bk.SampleKernel(KbranchParam, XForKernel)
         # Plot the sample
@@ -33,35 +42,80 @@ class TestSamplingAndPlotting(unittest.TestCase):
         BgridSearch = [0.0001, branchingPoint, 1.1]
         globalBranchingLabels = XForKernel[:, 1]  # use correct labels for tests
         # could add a mistake
-        print('Sparse model')
-        d = FitBranchingModel.FitModel(BgridSearch, XForKernel[:, 0], samples, globalBranchingLabels,
-                                       maxiter=40, priorConfidence=0.80, M=10)
-        bmode = BgridSearch[np.argmax(d['loglik'])]
-        print('tensorflow version', tf.__version__, 'GPflow version', gpflow.__version__)
-        print('TestSamplingAndPlotting:: Sparse Log likelihood', d['loglik'], 'BgridSearch', BgridSearch)
+        print("Sparse model")
+        d = FitBranchingModel.FitModel(
+            BgridSearch,
+            XForKernel[:, 0],
+            samples,
+            globalBranchingLabels,
+            maxiter=40,
+            priorConfidence=0.80,
+            M=10,
+        )
+        bmode = BgridSearch[np.argmax(d["loglik"])]
+        print(
+            "tensorflow version", tf.__version__, "GPflow version", gpflow.__version__
+        )
+        print(
+            "TestSamplingAndPlotting:: Sparse Log likelihood",
+            d["loglik"],
+            "BgridSearch",
+            BgridSearch,
+        )
         assert bmode == branchingPoint, bmode
         # Plot model
-        pred = d['prediction']  # prediction object from GP
-        _=bplot.plotBranchModel(bmode, XForKernel[:, 0], samples, pred['xtest'], pred['mu'], pred['var'],
-                                d['Phi'], fPlotPhi=True, fColorBar=True, fPlotVar = True)
+        pred = d["prediction"]  # prediction object from GP
+        _ = bplot.plotBranchModel(
+            bmode,
+            XForKernel[:, 0],
+            samples,
+            pred["xtest"],
+            pred["mu"],
+            pred["var"],
+            d["Phi"],
+            fPlotPhi=True,
+            fColorBar=True,
+            fPlotVar=True,
+        )
 
-        _=bplot.PlotBGPFit(samples, XForKernel[:, 0], BgridSearch, d)
-        d = FitBranchingModel.FitModel(BgridSearch, XForKernel[:, 0], samples, globalBranchingLabels,
-                                       maxiter=40, priorConfidence=0.80, M=0)
-        bmode = BgridSearch[np.argmax(d['loglik'])]
-        print('TestSamplingAndPlotting:: Dense Log likelihood', d['loglik'], 'BgridSearch', BgridSearch)
+        _ = bplot.PlotBGPFit(samples, XForKernel[:, 0], BgridSearch, d)
+        d = FitBranchingModel.FitModel(
+            BgridSearch,
+            XForKernel[:, 0],
+            samples,
+            globalBranchingLabels,
+            maxiter=40,
+            priorConfidence=0.80,
+            M=0,
+        )
+        bmode = BgridSearch[np.argmax(d["loglik"])]
+        print(
+            "TestSamplingAndPlotting:: Dense Log likelihood",
+            d["loglik"],
+            "BgridSearch",
+            BgridSearch,
+        )
         assert bmode == branchingPoint, bmode
-        print('Try sparse model with fixed hyperparameters')
-        d = FitBranchingModel.FitModel(BgridSearch, XForKernel[:, 0], samples, globalBranchingLabels,
-                                       maxiter=20, priorConfidence=0.80, M=15,
-                                       likvar=1e-3, kerlen=2., kervar=1., fixHyperparameters=True)
+        print("Try sparse model with fixed hyperparameters")
+        d = FitBranchingModel.FitModel(
+            BgridSearch,
+            XForKernel[:, 0],
+            samples,
+            globalBranchingLabels,
+            maxiter=20,
+            priorConfidence=0.80,
+            M=15,
+            likvar=1e-3,
+            kerlen=2.0,
+            kervar=1.0,
+            fixHyperparameters=True,
+        )
 
         # You can rerun the same code as many times as you want and get different sample paths
         # We can also sample independent functions. This is the assumption in the overlapping mixtures of GPs model (OMGP) discussed in the paper.
         indKernel = bk.IndKern(gpflow.kernels.SquaredExponential())
         samplesInd = bk.SampleKernel(indKernel, XForKernel)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()
-
-

--- a/testing/testSparseToFullModel.py
+++ b/testing/testSparseToFullModel.py
@@ -1,31 +1,33 @@
 # Generic libraries
+import unittest
+
 import gpflow
 import numpy as np
 import tensorflow as tf
-import unittest
+from gpflow import set_trainable
+
 # import pickle
 # Branching files
-from BranchedGP import VBHelperFunctions
 from BranchedGP import BranchingTree as bt
+from BranchedGP import VBHelperFunctions, assigngp_dense, assigngp_denseSparse
 from BranchedGP import branch_kernParamGPflow as bk
-from BranchedGP import assigngp_denseSparse
-from BranchedGP import assigngp_dense
-
-from gpflow import set_trainable
 
 
 class TestSparseVariational(unittest.TestCase):
     def InitParams(self, m):
         m.likelihood.variance.assign(0.1)
         # set lengthscale to maximum
-        m.kernel.kernels[0].kern.lengthscales.assign(1.)
+        m.kernel.kernels[0].kern.lengthscales.assign(1.0)
         # set process variance to average
-        m.kernel.kernels[0].kern.variance.assign(1.)
+        m.kernel.kernels[0].kern.variance.assign(1.0)
 
     def test_sparse(self):
         ls, lf = self.runSparseModel()
         lss, lf2 = self.runSparseModel(M=5, atolPrediction=1, atolLik=50)
-        self.assertTrue(np.allclose(lf, lf2, atol=1e-6), 'Not equal likelihoods for full models %f-%f' % (lf, lf2))
+        self.assertTrue(
+            np.allclose(lf, lf2, atol=1e-6),
+            "Not equal likelihoods for full models %f-%f" % (lf, lf2),
+        )
 
     def runSparseModel(self, M=None, atolPrediction=1e-3, atolLik=1):
         fDebug = True  # Enable debugging output - tensorflow print ops
@@ -37,7 +39,7 @@ class TestSparseVariational(unittest.TestCase):
         N = 20
         t = np.linspace(0, 1, N)
         print(t)
-        trueB = np.ones((1, 1))*0.5
+        trueB = np.ones((1, 1)) * 0.5
         Y = np.zeros((N, 1))
         idx = np.nonzero(t > 0.5)[0]
         idxA = idx[::2]
@@ -52,36 +54,59 @@ class TestSparseVariational(unittest.TestCase):
         tree.add(None, 1, trueB)
         (fm, _) = tree.GetFunctionBranchTensor()
         XExpanded, indices, _ = VBHelperFunctions.GetFunctionIndexListGeneral(t)
-        print('XExpanded', XExpanded.shape)
-        print('indices', len(indices))        # Create model
-        Kbranch = bk.BranchKernelParam(gpflow.kernels.Matern32(), fm, b=trueB.copy()) + gpflow.kernels.White()
-        Kbranch.kernels[0].kern.variance.assign(1.)
-        Kbranch.kernels[1].variance.assign(1e-6)  # controls the discontinuity magnitude, the gap at the branching point
+        print("XExpanded", XExpanded.shape)
+        print("indices", len(indices))  # Create model
+        Kbranch = (
+            bk.BranchKernelParam(gpflow.kernels.Matern32(), fm, b=trueB.copy())
+            + gpflow.kernels.White()
+        )
+        Kbranch.kernels[0].kern.variance.assign(1.0)
+        Kbranch.kernels[1].variance.assign(
+            1e-6
+        )  # controls the discontinuity magnitude, the gap at the branching point
         set_trainable(Kbranch.kernels[1].variance, False)  # jitter for numerics
-        print('Kbranch matrix', Kbranch.K(XExpanded, XExpanded))
-        print('Branching K free parameters', Kbranch.kernels[0])
-        print('Branching K branching parameter', Kbranch.kernels[0].Bv)
-        if(M is not None):
+        print("Kbranch matrix", Kbranch.K(XExpanded, XExpanded))
+        print("Branching K free parameters", Kbranch.kernels[0])
+        print("Branching K branching parameter", Kbranch.kernels[0].Bv)
+        if M is not None:
             ir = np.random.choice(XExpanded.shape[0], M)
             ZExpanded = XExpanded[ir, :]
         else:
             ZExpanded = XExpanded  # Test on full data
 
-        phiInitial =  np.ones((N, 2))*0.5  # dont know anything
-        mV = assigngp_denseSparse.AssignGPSparse(t, XExpanded, Y, Kbranch, indices,
-                                                 Kbranch.kernels[0].Bv, ZExpanded, phiInitial=phiInitial,
-                                                 fDebug=fDebug)
+        phiInitial = np.ones((N, 2)) * 0.5  # dont know anything
+        mV = assigngp_denseSparse.AssignGPSparse(
+            t,
+            XExpanded,
+            Y,
+            Kbranch,
+            indices,
+            Kbranch.kernels[0].Bv,
+            ZExpanded,
+            phiInitial=phiInitial,
+            fDebug=fDebug,
+        )
         self.InitParams(mV)
 
-        mVFull = assigngp_dense.AssignGP(t, XExpanded, Y, Kbranch, indices,
-                                         Kbranch.kernels[0].Bv, fDebug=fDebug, phiInitial=phiInitial)
+        mVFull = assigngp_dense.AssignGP(
+            t,
+            XExpanded,
+            Y,
+            Kbranch,
+            indices,
+            Kbranch.kernels[0].Bv,
+            fDebug=fDebug,
+            phiInitial=phiInitial,
+        )
         self.InitParams(mVFull)
 
         lsparse = mV.log_posterior_density()
         lfull = mVFull.log_posterior_density()
-        print('Log likelihoods, sparse=%f, full=%f' % (lsparse, lfull))
-        self.assertTrue(np.allclose(lsparse, lfull, atol=atolLik),
-                        'Log likelihoods not close, sparse=%f, full=%f' % (lsparse, lfull))
+        print("Log likelihoods, sparse=%f, full=%f" % (lsparse, lfull))
+        self.assertTrue(
+            np.allclose(lsparse, lfull, atol=atolLik),
+            "Log likelihoods not close, sparse=%f, full=%f" % (lsparse, lfull),
+        )
 
         # check models identical
         assert np.all(mV.GetPhiExpanded() == mVFull.GetPhiExpanded())
@@ -92,15 +117,20 @@ class TestSparseVariational(unittest.TestCase):
         Xtest = np.array([[0.6, 2], [0.6, 3]])
         mu_f, var_f = mVFull.predict_f(Xtest)
         mu_s, var_s = mV.predict_f(Xtest)
-        print('Sparse model mu=', mu_s, ' variance=', var_s)
-        print('Full model mu=', mu_f, ' variance=', var_f)
-        self.assertTrue(np.allclose(mu_s, mu_f, atol=atolPrediction),
-                        'mu not close sparse=%s - full=%s ' % (str(mu_s), str(mu_f)))
-        self.assertTrue(np.allclose(var_s, var_f, atol=atolPrediction),
-                        'var not close sparse=%s - full=%s ' % (str(var_s), str(var_f)))
+        print("Sparse model mu=", mu_s, " variance=", var_s)
+        print("Full model mu=", mu_f, " variance=", var_f)
+        self.assertTrue(
+            np.allclose(mu_s, mu_f, atol=atolPrediction),
+            "mu not close sparse=%s - full=%s " % (str(mu_s), str(mu_f)),
+        )
+        self.assertTrue(
+            np.allclose(var_s, var_f, atol=atolPrediction),
+            "var not close sparse=%s - full=%s " % (str(var_s), str(var_f)),
+        )
         return lsparse, lfull
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()
     # To run a specific test use
 #     suite = unittest.TestLoader().loadTestsFromTestCase(TestSparseVariational)

--- a/testing/testTree.py
+++ b/testing/testTree.py
@@ -1,17 +1,20 @@
 # Generic libraries
-import numpy as np
 import unittest
+
+import numpy as np
+
 # Branching files
 from BranchedGP import BranchingTree as bt
+
 
 class TestSparseVariational(unittest.TestCase):
     def test(self):
         tree = bt.BinaryBranchingTree(0, 1, fDebug=True)
         trueB = 0.2
         tree.add(None, 1, trueB)
-        tree.add(1, 2, trueB+0.1)
-        tree.add(2, 3, trueB+0.1+0.2)
-        tree.add(1, 4, trueB+0.1+0.3)
+        tree.add(1, 2, trueB + 0.1)
+        tree.add(2, 3, trueB + 0.1 + 0.2)
+        tree.add(1, 4, trueB + 0.1 + 0.3)
         assert tree.getRoot().idB == 1
         tree.getRoot().val == trueB
         tree.printTree()
@@ -20,5 +23,6 @@ class TestSparseVariational(unittest.TestCase):
         assert np.all(fm.shape == (9, 9, 4))
         assert np.all(fmb.shape == (9, 9, 4))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/testing/test_notebooks.py
+++ b/testing/test_notebooks.py
@@ -1,37 +1,43 @@
 from __future__ import print_function
+
+import glob
+import os
+import sys
+import time
+import traceback
+import unittest
+
 import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor
 from nbconvert.preprocessors.execute import CellExecutionError
-import glob
-import traceback
-import unittest
-import sys
-import time
-import os
 from nose.plugins.attrib import attr
 
 
-@attr(speed='slow')
+@attr(speed="slow")
 class TestNotebooks(unittest.TestCase):
     def _execNotebook(self, ep, notebook_filename, nbpath):
         with open(notebook_filename) as f:
             nb = nbformat.read(f, as_version=nbformat.current_nbformat)
             try:
-                ep.preprocess(nb, {'metadata': {'path': nbpath}})
+                ep.preprocess(nb, {"metadata": {"path": nbpath}})
             except CellExecutionError:
-                print('-' * 60)
+                print("-" * 60)
                 traceback.print_exc(file=sys.stdout)
-                print('-' * 60)
-                self.assertTrue(False, 'Error executing the notebook %s.\
-                                        See above for error.' % notebook_filename)
+                print("-" * 60)
+                self.assertTrue(
+                    False,
+                    "Error executing the notebook %s.\
+                                        See above for error."
+                    % notebook_filename,
+                )
 
     def test_all_notebooks(self):
-        ''' Test all notebooks except blacklist. Blacklisted notebooks take too long.'''
-        print('testing all notebooks')
-        blacklist = ['SyntheticData.ipynb']
-        pythonkernel = 'python'+str(sys.version_info[0])
+        """ Test all notebooks except blacklist. Blacklisted notebooks take too long."""
+        print("testing all notebooks")
+        blacklist = ["SyntheticData.ipynb"]
+        pythonkernel = "python" + str(sys.version_info[0])
         this_dir = os.path.dirname(__file__)
-        nbpath = os.path.join(this_dir, '../notebooks/')
+        nbpath = os.path.join(this_dir, "../notebooks/")
         # see http://nbconvert.readthedocs.io/en/stable/execute_api.html
         # ep = ExecutePreprocessor(timeout=120, kernel_name=pythonkernel, interrupt_on_timeout=True)
         # lfiles = glob.glob(nbpath+"*.ipynb")
@@ -43,5 +49,5 @@ class TestNotebooks(unittest.TestCase):
         #         print(notebook_filename, 'took %g seconds.' % (time.time()-t))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/testing/testpZ_construct.py
+++ b/testing/testpZ_construct.py
@@ -1,64 +1,88 @@
 # Generic libraries
+import unittest
+
 import gpflow
 import numpy as np
 import tensorflow as tf
-import unittest
+
 # Branching files
 from BranchedGP import pZ_construction_singleBP
 
 
 class TestpZ(unittest.TestCase):
     def test_pZ(self):
-        np.set_printoptions(suppress=True,  precision=2)
+        np.set_printoptions(suppress=True, precision=2)
         X = np.linspace(0, 1, 4, dtype=float)[:, None]
         X = np.sort(X, 0)
         with tf.compat.v1.Session():
             BP_tf = tf.compat.v1.placeholder(gpflow.default_float(), shape=[])
-            eZ0_tf = tf.compat.v1.placeholder(gpflow.default_float(), shape=(X.shape[0], X.shape[0]*3))
+            eZ0_tf = tf.compat.v1.placeholder(
+                gpflow.default_float(), shape=(X.shape[0], X.shape[0] * 3)
+            )
             pZ0 = np.array([[0.7, 0.3], [0.1, 0.9], [0.5, 0.5], [1, 0]])
             eZ0 = pZ_construction_singleBP.expand_pZ0(pZ0)
             for BP in [0, 0.2, 0.5, 1]:
-                print('========== BP %.2f ===========' % BP)
+                print("========== BP %.2f ===========" % BP)
                 pZ = tf.compat.v1.Session().run(
                     pZ_construction_singleBP.make_matrix(X, BP, eZ0_tf),
-                    feed_dict={BP_tf: BP, eZ0_tf: eZ0}
+                    feed_dict={BP_tf: BP, eZ0_tf: eZ0},
                 )
-                print('pZ0', pZ0)
-                print('eZ0', eZ0)
-                print('pZ', pZ)
-                for r, c in zip(range(0, X.shape[0]), range(0, X.shape[0]*3, 3)):
-                    print(X[r], pZ[r, c:c+3], pZ0[r, :])
-                    if(X[r] > BP):  # after branch point should be prior
-                        self.assertTrue(np.allclose(pZ[r, c+1:c+3], pZ0[r, :], atol=1e-6),
-                                        'must be the same! %s-%s' % (str(pZ[r, c:c+3]), str(pZ0[r, :])))
+                print("pZ0", pZ0)
+                print("eZ0", eZ0)
+                print("pZ", pZ)
+                for r, c in zip(range(0, X.shape[0]), range(0, X.shape[0] * 3, 3)):
+                    print(X[r], pZ[r, c : c + 3], pZ0[r, :])
+                    if X[r] > BP:  # after branch point should be prior
+                        self.assertTrue(
+                            np.allclose(pZ[r, c + 1 : c + 3], pZ0[r, :], atol=1e-6),
+                            "must be the same! %s-%s"
+                            % (str(pZ[r, c : c + 3]), str(pZ0[r, :])),
+                        )
                     else:
-                        self.assertTrue(np.allclose(pZ[r, c:c+3], np.array([1., 0., 0.]), atol=1e-6),
-                                        'must be the same! %s-%s' % (str(pZ[r, c:c+3]), str(pZ0[r, :])))
+                        self.assertTrue(
+                            np.allclose(
+                                pZ[r, c : c + 3], np.array([1.0, 0.0, 0.0]), atol=1e-6
+                            ),
+                            "must be the same! %s-%s"
+                            % (str(pZ[r, c : c + 3]), str(pZ0[r, :])),
+                        )
 
     def test_further(self):
-        np.set_printoptions(suppress=True,  precision=6)
+        np.set_printoptions(suppress=True, precision=6)
         # X = np.linspace(0, 1, 4, dtype=float)[:, None]
         X = np.array([0.1, 0.2, 0.3, 0.4])[:, None]
         with tf.compat.v1.Session():
             BP_tf = tf.compat.v1.placeholder(dtype=gpflow.default_float(), shape=[])
-            eZ0_tf = tf.compat.v1.placeholder(dtype=gpflow.default_float(), shape=(X.shape[0], X.shape[0]*3))
+            eZ0_tf = tf.compat.v1.placeholder(
+                dtype=gpflow.default_float(), shape=(X.shape[0], X.shape[0] * 3)
+            )
             pZ0 = np.array([[0.7, 0.3], [0.1, 0.9], [0.5, 0.5], [0.85, 0.15]])
             eZ0 = pZ_construction_singleBP.expand_pZ0(pZ0)
             BP = 0.2
             pZ = tf.compat.v1.Session().run(
                 pZ_construction_singleBP.make_matrix(X, BP_tf, eZ0_tf),
-                feed_dict={BP_tf: BP, eZ0_tf: eZ0}
+                feed_dict={BP_tf: BP, eZ0_tf: eZ0},
             )
-            print('pZ0', pZ0)
-            print('eZ0', eZ0)
-            print('pZ', pZ)
-            for r, c in zip(range(0, X.shape[0]), range(0, X.shape[0]*3, 3)):
+            print("pZ0", pZ0)
+            print("eZ0", eZ0)
+            print("pZ", pZ)
+            for r, c in zip(range(0, X.shape[0]), range(0, X.shape[0] * 3, 3)):
                 print(r, c)
-                print(X[r], pZ[r, c:c+3], pZ0[r, :])
-                if(X[r] > BP):  # after branch point should be prior
-                    assert np.allclose(pZ[r, c+1:c+3], pZ0[r, :], atol=1e-6), 'must be the same! %s-%s' % (str(pZ[r, c:c+3]), str(pZ0[r, :]))
+                print(X[r], pZ[r, c : c + 3], pZ0[r, :])
+                if X[r] > BP:  # after branch point should be prior
+                    assert np.allclose(
+                        pZ[r, c + 1 : c + 3], pZ0[r, :], atol=1e-6
+                    ), "must be the same! %s-%s" % (
+                        str(pZ[r, c : c + 3]),
+                        str(pZ0[r, :]),
+                    )
                 else:
-                    assert np.allclose(pZ[r, c:c+3], np.array([1., 0., 0.]), atol=1e-6), 'must be the same! %s-%s' % (str(pZ[r, c:c+3]), str(np.array([1., 0., 0.])))
+                    assert np.allclose(
+                        pZ[r, c : c + 3], np.array([1.0, 0.0, 0.0]), atol=1e-6
+                    ), "must be the same! %s-%s" % (
+                        str(pZ[r, c : c + 3]),
+                        str(np.array([1.0, 0.0, 0.0])),
+                    )
 
             eZ0z = pZ_construction_singleBP.expand_pZ0Zeros(pZ0)
             r = pZ_construction_singleBP.expand_pZ0PureNumpyZeros(eZ0z, BP, X)
@@ -67,11 +91,11 @@ class TestpZ(unittest.TestCase):
             # try another
             pZ = tf.compat.v1.Session().run(
                 pZ_construction_singleBP.make_matrix(X, BP_tf, eZ0_tf),
-                feed_dict={BP_tf: 0.3, eZ0_tf: eZ0}
+                feed_dict={BP_tf: 0.3, eZ0_tf: eZ0},
             )
             r = pZ_construction_singleBP.expand_pZ0PureNumpyZeros(eZ0z, 0.3, X)
             assert np.allclose(r, pZ, atol=1e-5)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR enables us to avoid discussing code formatting ever again.

[Black](https://black.readthedocs.io/en/stable) and [isort](https://pycqa.github.io/isort) are great tools that make code look nice without having to spend any time manually tweaking layout. Moreover, they ensure we stick to the formatting guidelines from [PEP8](https://www.python.org/dev/peps/pep-0008/). This should make our codebase more welcoming for newcomers.

This PR:
* Configures the above tools correctly,
* Runs them on our codebase, and
* Adds them to the repo builds. This will mean that new PRs will be rejected unless people run `make format` before committing their changes. This can be a little bit annoying for contributors, but hopefully the ease of use and the additional docs in README make this a worthwhile change.

Please review commit-by-commit (and read the commit messages for details).

Note that this PR is actually really small - most of the changes are in the commit that runs black and isort on our codebase. That commit does *not* change any code behaviour, so you can actually avoid inspecting it in detail.  

*Question:* should we add a git pre-commit hook that always runs the format check for us? Each user would have to do a bit of work to set this up and it can be a little bit fiddly. On the plus side, you get automatic format checking.