### PR TITLE
Bump up the required TF version to 2.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=['BranchedGP'],
     package_data={},
     install_requires=[
-        "tensorflow>=2,<3",
+        "tensorflow>=2.4,<3",
         "gpflow>=2,<3",
         "matplotlib",
     ],

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -22,6 +22,7 @@ defusedxml==0.6.0
 dm-tree==0.1.5
 entrypoints==0.3
 flake8==3.8.4
+flatbuffers==1.12
 gast==0.3.3
 google-auth==1.22.0
 google-auth-oauthlib==0.4.1
@@ -62,8 +63,8 @@ nbconvert==6.0.7
 nbformat==5.0.7
 nest-asyncio==1.4.1
 nose==1.3.7
-notebook==6.1.4
-numpy==1.18.5
+notebook==6.1.5
+numpy==1.19.4
 oauthlib==3.1.0
 opt-einsum==3.3.0
 packaging==20.4
@@ -103,10 +104,10 @@ scipy==1.5.2
 Send2Trash==1.5.0
 six==1.15.0
 tabulate==0.8.7
-tensorboard==2.3.0
+tensorboard==2.4.0
 tensorboard-plugin-wit==1.7.0
-tensorflow==2.3.1
-tensorflow-estimator==2.3.0
+tensorflow==2.4.0
+tensorflow-estimator==2.4.0
 tensorflow-probability==0.11.1
 termcolor==1.1.0
 terminado==0.9.1


### PR DESCRIPTION
This is due to the long list of security issues addressed in 2.4.0,
see https://github.com/tensorflow/tensorflow/releases/tag/v2.4.0 for details